### PR TITLE
feat: JSON builder API [DHIS2-12235]

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ which exposes all node types as `JsonNode`.
 `JsonValue`s are **virtual** 👻:
 * high level abstraction
 * what we believe we got back
-* navigation without requiring existence
-* extendable tree
+* navigation without requiring existence (no exceptions)
+* extendable tree API
 
 `JsonNode`s are **actual** ☠️:
 * low level abstraction
 * what we actually got back
-* navigation demands existence
-* not extendable tree
+* navigation demands existence (otherwise throws exceptions)
+* non-extendable tree API
 
 Tree Navigation
 

--- a/src/main/java/org/hisp/dhis/jsontree/JsonAppender.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonAppender.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.jsontree;
+
+import java.io.PrintStream;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.hisp.dhis.jsontree.JsonBuilder.JsonArrayBuilder;
+import org.hisp.dhis.jsontree.JsonBuilder.JsonObjectBuilder;
+
+/**
+ * An "append only" {@link JsonBuilder} implementation that can be used with a
+ * {@link PrintStream} or a {@link StringBuilder}.
+ *
+ * @author Jan Bernitt
+ */
+public class JsonAppender implements JsonBuilder, JsonObjectBuilder, JsonArrayBuilder
+{
+
+    public interface CharConsumer
+    {
+
+        void accept( char c );
+    }
+
+    private final Consumer<CharSequence> appendStr;
+
+    private final CharConsumer appendChar;
+
+    private final Supplier<String> toStr;
+
+    private final boolean[] addedByLevel = new boolean[128];
+
+    private int level = 0;
+
+    public JsonAppender( PrintStream out )
+    {
+        this( out::append, out::append, () -> null );
+    }
+
+    public JsonAppender( StringBuilder out )
+    {
+        this( out::append, out::append, out::toString );
+    }
+
+    public JsonAppender( Consumer<CharSequence> appendStr, CharConsumer appendChar, Supplier<String> toStr )
+    {
+        this.appendStr = appendStr;
+        this.appendChar = appendChar;
+        this.toStr = toStr;
+    }
+
+    private void append( char c )
+    {
+        appendChar.accept( c );
+    }
+
+    private void append( CharSequence str )
+    {
+        appendStr.accept( str );
+    }
+
+    private void appendCommaWhenNeeded()
+    {
+        if ( !addedByLevel[level] )
+        {
+            addedByLevel[level] = true;
+        }
+        else
+        {
+            append( ',' );
+        }
+    }
+
+    private void appendEscaped( CharSequence str )
+    {
+        str.chars().forEachOrdered( c -> {
+            if ( c == '"' || c == '\\' || c <= ' ' )
+            {
+                appendChar.accept( '\\' );
+            }
+            appendChar.accept( (char) c );
+        } );
+    }
+
+    private void beginLevel( char c )
+    {
+        append( c );
+        addedByLevel[++level] = false;
+    }
+
+    private void endLevel( char c )
+    {
+        append( c );
+        level--;
+    }
+
+    @Override
+    public JsonNode toObject( Consumer<JsonObjectBuilder> value )
+    {
+        beginLevel( '{' );
+        value.accept( this );
+        endLevel( '}' );
+        return new JsonDocument( toStr.get() ).get( "$" );
+
+    }
+
+    @Override
+    public JsonNode toArray( Consumer<JsonArrayBuilder> value )
+    {
+        beginLevel( '[' );
+        value.accept( this );
+        endLevel( ']' );
+        return new JsonDocument( toStr.get() ).get( "$" );
+    }
+
+    /*
+     * JsonObjectBuilder
+     */
+
+    private JsonObjectBuilder addRawMember( String name, CharSequence rawValue )
+    {
+        appendCommaWhenNeeded();
+        append( '"' );
+        append( name );
+        append( '"' );
+        append( ':' );
+        append( rawValue );
+        return this;
+    }
+
+    @Override
+    public JsonObjectBuilder addMember( String name, JsonNode value )
+    {
+        return addRawMember( name, value.getDeclaration() );
+    }
+
+    @Override
+    public JsonObjectBuilder addBoolean( String name, boolean value )
+    {
+        return addRawMember( name, value ? "true" : "false" );
+    }
+
+    @Override
+    public JsonObjectBuilder addBoolean( String name, Boolean value )
+    {
+        return addRawMember( name, value == null ? "null" : value ? "true" : "false" );
+    }
+
+    @Override
+    public JsonObjectBuilder addNumber( String name, int value )
+    {
+        return addRawMember( name, String.valueOf( value ) );
+    }
+
+    @Override
+    public JsonObjectBuilder addNumber( String name, long value )
+    {
+        return addRawMember( name, String.valueOf( value ) );
+    }
+
+    @Override
+    public JsonObjectBuilder addNumber( String name, double value )
+    {
+        return addRawMember( name, String.valueOf( value ) );
+    }
+
+    @Override
+    public JsonObjectBuilder addNumber( String name, Number value )
+    {
+        return addRawMember( name, value == null ? "null" : value.toString() );
+    }
+
+    @Override
+    public JsonObjectBuilder addString( String name, String value )
+    {
+        appendCommaWhenNeeded();
+        append( '"' );
+        append( name );
+        append( "\":\"" );
+        appendEscaped( value );
+        append( '"' );
+        return this;
+    }
+
+    @Override
+    public JsonObjectBuilder addArray( String name, Consumer<JsonArrayBuilder> value )
+    {
+        appendCommaWhenNeeded();
+        append( '"' );
+        append( name );
+        append( '"' );
+        append( ':' );
+        beginLevel( '[' );
+        value.accept( this );
+        endLevel( ']' );
+        return this;
+    }
+
+    @Override
+    public JsonObjectBuilder addObject( String name, Consumer<JsonObjectBuilder> value )
+    {
+        appendCommaWhenNeeded();
+        append( '"' );
+        append( name );
+        append( '"' );
+        append( ':' );
+        beginLevel( '{' );
+        value.accept( this );
+        endLevel( '}' );
+        return this;
+    }
+
+    @Override
+    public <K, V> JsonObjectBuilder addObject( String name, Map<K, V> value,
+        TriConsumer<JsonObjectBuilder, ? super K, ? super V> toMember )
+    {
+        if ( name == null )
+        {
+            value.forEach( ( k, v ) -> toMember.accept( this, k, v ) );
+            return this;
+        }
+        appendCommaWhenNeeded();
+        append( '"' );
+        append( name );
+        append( '"' );
+        append( ':' );
+        beginLevel( '{' );
+        value.forEach( ( k, v ) -> toMember.accept( this, k, v ) );
+        endLevel( '}' );
+        return this;
+    }
+
+    @Override
+    public JsonObjectBuilder addMember( String name, Object pojo, JsonMapper mapper )
+    {
+        mapper.addTo( this, null, pojo );
+        return this;
+    }
+
+    /*
+     * JsonArrayBuilder
+     */
+
+    private JsonArrayBuilder addRawElement( CharSequence rawValue )
+    {
+        appendCommaWhenNeeded();
+        appendStr.accept( rawValue );
+        return this;
+    }
+
+    @Override
+    public JsonArrayBuilder addElement( JsonNode value )
+    {
+        return addRawElement( value.getDeclaration() );
+    }
+
+    @Override
+    public JsonArrayBuilder addBoolean( boolean value )
+    {
+        return addRawElement( value ? "true" : "false" );
+    }
+
+    @Override
+    public JsonArrayBuilder addBoolean( Boolean value )
+    {
+        return addRawElement( value == null ? "null" : value ? "true" : "false" );
+    }
+
+    @Override
+    public JsonArrayBuilder addNumber( int value )
+    {
+        return addRawElement( String.valueOf( value ) );
+    }
+
+    @Override
+    public JsonArrayBuilder addNumber( long value )
+    {
+        return addRawElement( String.valueOf( value ) );
+    }
+
+    @Override
+    public JsonArrayBuilder addNumber( double value )
+    {
+        return addRawElement( String.valueOf( value ) );
+    }
+
+    @Override
+    public JsonArrayBuilder addNumber( Number value )
+    {
+        return addRawElement( value == null ? "null" : value.toString() );
+    }
+
+    @Override
+    public JsonArrayBuilder addString( String value )
+    {
+        appendCommaWhenNeeded();
+        append( '"' );
+        appendEscaped( value );
+        append( '"' );
+        return this;
+    }
+
+    @Override
+    public JsonArrayBuilder addArray( Consumer<JsonArrayBuilder> value )
+    {
+        appendCommaWhenNeeded();
+        beginLevel( '[' );
+        value.accept( this );
+        endLevel( ']' );
+        return this;
+    }
+
+    @Override
+    public <E> JsonArrayBuilder addArray( Stream<E> values, BiConsumer<JsonArrayBuilder, ? super E> toElement )
+    {
+        appendCommaWhenNeeded();
+        beginLevel( '[' );
+        values.forEachOrdered( v -> toElement.accept( this, v ) );
+        endLevel( ']' );
+        return this;
+    }
+
+    @Override
+    public JsonArrayBuilder addObject( Consumer<JsonObjectBuilder> value )
+    {
+        appendCommaWhenNeeded();
+        beginLevel( '{' );
+        value.accept( this );
+        endLevel( '}' );
+        return this;
+    }
+
+    @Override
+    public <K, V> JsonObjectBuilder addObject( Map<K, V> value,
+        TriConsumer<JsonObjectBuilder, ? super K, ? super V> toMember )
+    {
+        appendCommaWhenNeeded();
+        beginLevel( '{' );
+        value.forEach( ( k, v ) -> toMember.accept( this, k, v ) );
+        endLevel( '}' );
+        return this;
+    }
+
+    @Override
+    public JsonArrayBuilder addElement( Object value, JsonMapper mapper )
+    {
+        mapper.addTo( this, value );
+        return this;
+    }
+
+}

--- a/src/main/java/org/hisp/dhis/jsontree/JsonBuilder.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonBuilder.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.jsontree;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+/**
+ * A {@link JsonNode} builder API that mostly is designed to efficiently create
+ * JSON in a streaming scenario or when programmatically declaring a JSON
+ * structure.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonBuilder
+{
+    /**
+     * Like a {@link BiConsumer} but with 3 inputs.
+     */
+    interface TriConsumer<A, B, C>
+    {
+        void accept( A a, B b, C c );
+    }
+
+    /**
+     * Define a {@link JsonNode} that is a {@link JsonObject}.
+     *
+     * @param value fluent API to define the members of the JSON object created
+     * @return the {@link JsonNode} representing the created object, might
+     *         return {@code null} in case the content is only written to an
+     *         output stream and cannot be accessed as {@link JsonNode} value
+     */
+    JsonNode toObject( Consumer<JsonObjectBuilder> value );
+
+    /**
+     * Define a {@link JsonNode} that is a {@link JsonArray}.
+     *
+     * @param value fluent API to define the elements of the JSON array created
+     * @return the {@link JsonNode} representing the created array, might return
+     *         {@code null} in case the content is only written to an output
+     *         stream and cannot be accessed as {@link JsonNode} value
+     */
+    JsonNode toArray( Consumer<JsonArrayBuilder> value );
+
+    default JsonNode toObject( Object pojo, JsonMapper mapper )
+    {
+        return toObject( obj -> obj.addMembers( pojo, mapper ) );
+    }
+
+    /**
+     * Maps POJOs to JSON by using the provided builder to append the builder
+     * representation of the POJO to the currently built JSON tree.
+     *
+     * The mapping is intentionally not built into the {@link JsonBuilder} as
+     * different builder implementation might be useful in combination with
+     * different mappers in different scenarios. By having the mapping being an
+     * explicit support abstraction this allows to combine any combination of
+     * the two while also keeping each simple and focussed on solving a single
+     * problem.
+     *
+     * @author Jan Bernitt
+     */
+    interface JsonMapper
+    {
+
+        /**
+         * Adds a POJO java object to a currently built array.
+         *
+         * @param builder to use to append the object to as an element
+         * @param value the POJO to append as an element
+         */
+        void addTo( JsonArrayBuilder builder, Object value );
+
+        /**
+         * Adds a POJO java object as the currently built object or if a name is
+         * provided as a member within that built object.
+         *
+         * @param builder to use to append the POJO fields as member field(s)
+         * @param name name of the field in JSON or {@code null} if the POJO
+         *        fields should become the member fields
+         * @param value the POJO to append as an object or member
+         */
+        void addTo( JsonObjectBuilder builder, String name, Object value );
+    }
+
+    /**
+     * Builder API to add members to JSON object node.
+     *
+     * @author Jan Bernitt
+     */
+    interface JsonObjectBuilder
+    {
+        JsonObjectBuilder addMember( String name, JsonNode value );
+
+        JsonObjectBuilder addBoolean( String name, boolean value );
+
+        JsonObjectBuilder addBoolean( String name, Boolean value );
+
+        JsonObjectBuilder addNumber( String name, int value );
+
+        JsonObjectBuilder addNumber( String name, long value );
+
+        JsonObjectBuilder addNumber( String name, double value );
+
+        JsonObjectBuilder addNumber( String name, Number value );
+
+        JsonObjectBuilder addString( String name, String value );
+
+        JsonObjectBuilder addArray( String name, Consumer<JsonArrayBuilder> value );
+
+        JsonObjectBuilder addObject( String name, Consumer<JsonObjectBuilder> value );
+
+        <K, V> JsonObjectBuilder addObject( String name, Map<K, V> value,
+            TriConsumer<JsonObjectBuilder, ? super K, ? super V> toMember );
+
+        JsonObjectBuilder addMember( String name, Object pojo, JsonMapper mapper );
+
+        default JsonObjectBuilder addMembers( Object pojo, JsonMapper mapper )
+        {
+            return addMember( null, pojo, mapper );
+        }
+
+        default <K, V> JsonObjectBuilder addMembers( Map<K, V> value,
+            TriConsumer<JsonObjectBuilder, ? super K, ? super V> toMember )
+        {
+            return addObject( null, value, toMember );
+        }
+
+        default <V> JsonObjectBuilder addArray( String name, Stream<V> value,
+            BiConsumer<JsonArrayBuilder, ? super V> toElement )
+        {
+            return addArray( name, arr -> value.forEachOrdered( v -> toElement.accept( arr, v ) ) );
+        }
+
+        default <V> JsonObjectBuilder addArray( String name, Collection<V> value,
+            BiConsumer<JsonArrayBuilder, V> toElement )
+        {
+            return addArray( name, value.stream(), toElement );
+        }
+
+        default JsonObjectBuilder addArray( String name, String... value )
+        {
+            return addArray( name, List.of( value ), JsonArrayBuilder::addString );
+        }
+
+        default JsonObjectBuilder addArray( String name, int... value )
+        {
+            return addArray( name, IntStream.of( value ).boxed(), JsonArrayBuilder::addNumber );
+        }
+
+        default JsonObjectBuilder addArray( String name, long... value )
+        {
+            return addArray( name, LongStream.of( value ).boxed(), JsonArrayBuilder::addNumber );
+        }
+
+        default JsonObjectBuilder addArray( String name, double... value )
+        {
+            return addArray( name, DoubleStream.of( value ).boxed(), JsonArrayBuilder::addNumber );
+        }
+
+        default <V> JsonObjectBuilder addArray( String name, V[] value,
+            BiConsumer<JsonArrayBuilder, ? super V> toElement )
+        {
+            return addArray( name, Arrays.stream( value ), toElement );
+        }
+
+        default <V, X> JsonObjectBuilder addArray( String name, V[] value,
+            BiConsumer<JsonArrayBuilder, X> add, Function<? super V, X> toElement )
+        {
+            return addArray( name, value, ( arr, v ) -> add.accept( arr, toElement.apply( v ) ) );
+        }
+
+    }
+
+    /**
+     * Builder API to add elements to JSON array node.
+     *
+     * @author Jan Bernitt
+     */
+    interface JsonArrayBuilder
+    {
+        JsonArrayBuilder addElement( JsonNode value );
+
+        JsonArrayBuilder addBoolean( boolean value );
+
+        JsonArrayBuilder addBoolean( Boolean value );
+
+        JsonArrayBuilder addNumber( int value );
+
+        JsonArrayBuilder addNumber( long value );
+
+        JsonArrayBuilder addNumber( double value );
+
+        JsonArrayBuilder addNumber( Number value );
+
+        JsonArrayBuilder addString( String value );
+
+        JsonArrayBuilder addArray( Consumer<JsonArrayBuilder> value );
+
+        <E> JsonArrayBuilder addArray( Stream<E> values, BiConsumer<JsonArrayBuilder, ? super E> toElement );
+
+        JsonArrayBuilder addObject( Consumer<JsonObjectBuilder> value );
+
+        <K, V> JsonObjectBuilder addObject( Map<K, V> value,
+            TriConsumer<JsonObjectBuilder, ? super K, ? super V> toMember );
+
+        JsonArrayBuilder addElement( Object value, JsonMapper mapper );
+
+        default JsonArrayBuilder addArray( String... values )
+        {
+            return addArray( List.of( values ), JsonArrayBuilder::addString );
+        }
+
+        default JsonArrayBuilder addArray( int... values )
+        {
+            return addArray( IntStream.of( values ).boxed(), JsonArrayBuilder::addNumber );
+        }
+
+        default JsonArrayBuilder addArray( long... values )
+        {
+            return addArray( LongStream.of( values ).boxed(), JsonArrayBuilder::addNumber );
+        }
+
+        default JsonArrayBuilder addArray( double... values )
+        {
+            return addArray( DoubleStream.of( values ).boxed(), JsonArrayBuilder::addNumber );
+        }
+
+        default JsonArrayBuilder addArray( Number[] values )
+        {
+            return addArray( values, JsonArrayBuilder::addNumber );
+        }
+
+        default <E> JsonArrayBuilder addArray( E[] values, BiConsumer<JsonArrayBuilder, ? super E> toElement )
+        {
+            return addArray( Arrays.stream( values ), toElement );
+        }
+
+        default <E, X> JsonArrayBuilder addArray( E[] values,
+            BiConsumer<JsonArrayBuilder, X> add, Function<? super E, X> toElement )
+        {
+            return addArray( values, ( arr, v ) -> add.accept( arr, toElement.apply( v ) ) );
+        }
+
+        default <E> JsonArrayBuilder addArray( Collection<E> values, BiConsumer<JsonArrayBuilder, ? super E> toElement )
+        {
+            return addArray( values.stream(), toElement );
+        }
+
+        default <E, X> JsonArrayBuilder addArray( Collection<E> values, BiConsumer<JsonArrayBuilder, X> add,
+            Function<? super E, X> toElement )
+        {
+            return addArray( values, ( arr, v ) -> add.accept( arr, toElement.apply( v ) ) );
+        }
+    }
+}

--- a/src/test/java/org/hisp/dhis/jsontree/JsonAppenderTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonAppenderTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.jsontree;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+
+import java.lang.annotation.RetentionPolicy;
+import java.math.BigInteger;
+import java.util.List;
+
+import org.hisp.dhis.jsontree.JsonBuilder.JsonArrayBuilder;
+import org.hisp.dhis.jsontree.JsonBuilder.JsonObjectBuilder;
+import org.junit.Test;
+
+/**
+ * Tests the {@link JsonAppender} implementation of a {@link JsonBuilder}.
+ *
+ * @author Jan Bernitt
+ */
+public class JsonAppenderTest
+{
+
+    private final JsonBuilder builder = new JsonAppender( new StringBuilder() );
+
+    @Test
+    public void testObject_Boolean()
+    {
+        assertJson( "{'a':true,'b':false,'c':null}", builder.toObject( obj -> obj
+            .addBoolean( "a", true )
+            .addBoolean( "b", false )
+            .addBoolean( "c", null ) ) );
+    }
+
+    @Test
+    public void testArray_Boolean()
+    {
+        assertJson( "[true,false,null]", builder.toArray( arr -> arr
+            .addBoolean( true )
+            .addBoolean( false )
+            .addBoolean( null ) ) );
+    }
+
+    @Test
+    public void testObject_Int()
+    {
+        assertJson( "{'int':42}", builder.toObject( obj -> obj
+            .addNumber( "int", 42 ) ) );
+    }
+
+    @Test
+    public void testArray_Int()
+    {
+        assertJson( "[42]", builder.toArray( arr -> arr
+            .addNumber( 42 ) ) );
+    }
+
+    @Test
+    public void testObject_Double()
+    {
+        assertJson( "{'double':42.42}", builder.toObject( obj -> obj
+            .addNumber( "double", 42.42 ) ) );
+    }
+
+    @Test
+    public void testArray_Double()
+    {
+        assertJson( "[42.42]", builder.toArray( arr -> arr
+            .addNumber( 42.42 ) ) );
+    }
+
+    @Test
+    public void testObject_Long()
+    {
+        assertJson( "{'long':" + Long.MAX_VALUE + "}", builder.toObject( obj -> obj
+            .addNumber( "long", Long.MAX_VALUE ) ) );
+    }
+
+    @Test
+    public void testArray_Long()
+    {
+        assertJson( "[" + Long.MAX_VALUE + "]", builder.toArray( arr -> arr
+            .addNumber( Long.MAX_VALUE ) ) );
+    }
+
+    @Test
+    public void testObject_BigInteger()
+    {
+        assertJson( "{'bint':42}", builder.toObject( obj -> obj
+            .addNumber( "bint", BigInteger.valueOf( 42L ) ) ) );
+    }
+
+    @Test
+    public void testArray_BigInteger()
+    {
+        assertJson( "[42]", builder.toArray( arr -> arr
+            .addNumber( BigInteger.valueOf( 42L ) ) ) );
+    }
+
+    @Test
+    public void testObject_String()
+    {
+        assertJson( "{'s':'hello'}", builder.toObject( obj -> obj
+            .addString( "s", "hello" ) ) );
+    }
+
+    @Test
+    public void testArray_String()
+    {
+        assertJson( "['hello']", builder.toArray( arr -> arr
+            .addString( "hello" ) ) );
+    }
+
+    @Test
+    public void testObject_IntArray()
+    {
+        assertJson( "{'array':[1,2]}", builder.toObject( obj -> obj
+            .addArray( "array", 1, 2 ) ) );
+    }
+
+    @Test
+    public void testArray_IntArray()
+    {
+        assertJson( "[[1,2]]", builder.toArray( arr -> arr
+            .addArray( 1, 2 ) ) );
+    }
+
+    @Test
+    public void testObject_DoubleArray()
+    {
+        assertJson( "{'array':[1.5,2.5]}", builder.toObject( obj -> obj
+            .addArray( "array", 1.5d, 2.5d ) ) );
+    }
+
+    @Test
+    public void testArray_DoubleArray()
+    {
+        assertJson( "[[1.5,2.5]]", builder.toArray( arr -> arr
+            .addArray( 1.5d, 2.5d ) ) );
+    }
+
+    @Test
+    public void testObject_LongArray()
+    {
+        assertJson( "{'array':[" + Long.MIN_VALUE + "," + Long.MAX_VALUE + "]}", builder.toObject( obj -> obj
+            .addArray( "array", Long.MIN_VALUE, Long.MAX_VALUE ) ) );
+    }
+
+    @Test
+    public void testArray_LongArray()
+    {
+        assertJson( "[[" + Long.MIN_VALUE + "," + Long.MAX_VALUE + "]]", builder.toArray( arr -> arr
+            .addArray( Long.MIN_VALUE, Long.MAX_VALUE ) ) );
+    }
+
+    @Test
+    public void testObject_StringArray()
+    {
+        assertJson( "{'array':['a','b']}", builder.toObject( obj -> obj
+            .addArray( "array", "a", "b" ) ) );
+    }
+
+    @Test
+    public void testArray_StringArray()
+    {
+        assertJson( "[['a','b']]", builder.toArray( arr -> arr
+            .addArray( "a", "b" ) ) );
+    }
+
+    @Test
+    public void testObject_OtherArray()
+    {
+        assertJson( "{'array':['SOURCE','CLASS','RUNTIME']}", builder.toObject( obj -> obj
+            .addArray( "array", RetentionPolicy.values(), JsonArrayBuilder::addString, RetentionPolicy::name ) ) );
+    }
+
+    @Test
+    public void testArray_OtherArray()
+    {
+        assertJson( "[['SOURCE','CLASS','RUNTIME']]", builder.toArray( arr -> arr
+            .addArray( RetentionPolicy.values(), JsonArrayBuilder::addString, RetentionPolicy::name ) ) );
+    }
+
+    @Test
+    public void testArray_OtherCollection()
+    {
+        assertJson( "[['SOURCE','CLASS','RUNTIME']]", builder.toArray( arr -> arr
+            .addArray( List.of( RetentionPolicy.values() ), JsonArrayBuilder::addString, RetentionPolicy::name ) ) );
+    }
+
+    @Test
+    public void testObject_StreamArray()
+    {
+        assertJson( "{'a2':[['a'],['b','c']]}", builder.toObject( obj -> obj
+            .addArray( "a2", List.of( "a", "bc" ),
+                ( arr, e ) -> arr.addArray( e.codePoints().boxed(),
+                    ( innerArr, c ) -> innerArr.addString( Character.toString( c ) ) ) ) ) );
+    }
+
+    @Test
+    public void testArray_StreamArray()
+    {
+        assertJson( "[[['a'],['b','c']]]", builder.toArray( arr -> arr
+            .addArray( List.of( "a", "bc" ),
+                ( arr2, e ) -> arr2.addArray( e.codePoints().boxed(),
+                    ( innerArr, c ) -> innerArr.addString( Character.toString( c ) ) ) ) ) );
+    }
+
+    @Test
+    public void testObject_ObjectBuilder()
+    {
+        assertJson( "{'obj':{'inner':42}}", builder.toObject( outer -> outer
+            .addObject( "obj", obj -> obj.addNumber( "inner", 42 ) ) ) );
+    }
+
+    @Test
+    public void testArray_ObjectBuilder()
+    {
+        assertJson( "[[42,14]]", builder.toArray( arr -> arr
+            .addArray( arr2 -> arr2.addNumber( 42 ).addNumber( 14 ) ) ) );
+    }
+
+    @Test
+    public void testArray_ArrayBuilder()
+    {
+        assertJson( "[{'inner':42}]", builder.toArray( arr -> arr
+            .addObject( obj -> obj.addNumber( "inner", 42 ) ) ) );
+    }
+
+    @Test
+    public void testObject_ObjectMap()
+    {
+        assertJson( "{'obj':{'field':42}}", builder.toObject( outer -> outer
+            .addObject( "obj", singletonMap( "field", 42 ), JsonObjectBuilder::addNumber ) ) );
+    }
+
+    @Test
+    public void testArray_ObjectMap()
+    {
+        assertJson( "[{'field':42}]", builder.toArray( arr -> arr
+            .addObject( singletonMap( "field", 42 ), JsonObjectBuilder::addNumber ) ) );
+    }
+
+    @Test
+    public void testObject_MembersMap()
+    {
+        assertJson( "{'field':42}", builder.toObject( outer -> outer
+            .addMembers( singletonMap( "field", 42 ), JsonObjectBuilder::addNumber ) ) );
+    }
+
+    @Test
+    public void testArray_ElementsCollection()
+    {
+        assertJson( "[[42]]", builder.toArray( arr -> arr
+            .addArray( singletonList( 42 ), JsonArrayBuilder::addNumber ) ) );
+    }
+
+    @Test
+    public void testObject_JsonNode()
+    {
+        assertJson( "{'node':['a','b']}", builder.toObject( obj -> obj
+            .addMember( "node", new JsonDocument( "[\"a\",\"b\"]" ).get( "$" ) ) ) );
+    }
+
+    @Test
+    public void testArray_JsonNode()
+    {
+        assertJson( "[['a','b']]", builder.toArray( arr -> arr
+            .addElement( new JsonDocument( "[\"a\",\"b\"]" ).get( "$" ) ) ) );
+    }
+
+    private static void assertJson( String expected, JsonNode actual )
+    {
+        assertEquals( expected.replace( '\'', '"' ), actual.getDeclaration() );
+    }
+}


### PR DESCRIPTION
### Summary
Basic design of a JSON builder API.

The API is designed to create `JsonNode` or stream the JSON to an output stream with good performance and high degree of flexibility. This is archived by building on lambdas which requires a bit of  getting used to but provides a convenient solution for deeply nested complex JSON trees that can be implemented with good performance and close to no overhead without getting complex. This balance of readability, flexibility and performance is intentional. 

Mapping POJO objects to JSON is conceptually integrated in the builder API but the mapping itself is an API on its on so it can be implemented independently of JSON building. 

### Automated Testing
Adds unit tests for API methods except those that depend on the `JsonMapper` which has not been implemented yet.