### PR TITLE
fix: Add POM configuration to allow for maven deploy phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
+# Eclipse
+
+.classpath
+.project
+.settings
+
 # Package Files #
 *.jar
 *.war

--- a/README.md
+++ b/README.md
@@ -126,3 +126,11 @@ Directly writing JSON to an output stream:
 
     JsonBuilder.streamObject( out, 
         obj -> obj.addString( "name", "value" ) );
+
+## Deploy to Maven Repository
+
+This library can be deployed as an artefact to the Sonatype OSS Maven repository. The deployment plugins are defined in
+a separate profile to avoid performing GPG key signing during regular build processes. To deploy invoke:
+
+	mvn clean deploy -P deploy
+

--- a/README.md
+++ b/README.md
@@ -239,3 +239,11 @@ changed by this, just the view on top of it is transformed.
 
 Such transformation can be especially useful in combination with `toList` to
 extract a list of the values that can be compared to an expected list. 
+
+
+## Deploy to Maven Repository
+
+This library can be deployed as an artefact to the Sonatype OSS Maven repository. The deployment plugins are defined in
+a separate profile to avoid performing GPG key signing during regular build processes. To deploy invoke:
+
+	mvn clean deploy -P deploy

--- a/pom.xml
+++ b/pom.xml
@@ -144,32 +144,42 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                    <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>deploy</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.8</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>            
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <packaging>jar</packaging>
     <name>DHIS JSON Tree</name>
     <url>https://github.com/dhis2/json-tree</url>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
 
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,15 @@
     <artifactId>json-tree</artifactId>
     <packaging>jar</packaging>
     <name>DHIS JSON Tree</name>
-    <version>0.0.1-SNAPSHOT</version>
+    <url>https://github.com/dhis2/json-tree</url>
+    <version>0.1.0</version>
 
     <developers>
         <developer>
             <id>jbee</id>
             <name>Jan Bernitt</name>
             <email>jbernitt@dhis2.org</email>
+            <organizationUrl>https://dhis2.org</organizationUrl>
         </developer>
     </developers>
 
@@ -38,6 +40,17 @@
         </license>
     </licenses>
 
+    <scm>
+        <connection>scm:git:git@github.com:dhis2/json-tree.git</connection>
+        <developerConnection>scm:git:git@github.com:dhis2/json-tree.gitt</developerConnection>
+        <url>git@github.com:dhis2/json-tree.git</url>
+    </scm>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/dhis2/json-tree</url>
+    </issueManagement>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -51,6 +64,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+        </repository>
+    </distributionManagement>
 
     <build>
         <plugins>
@@ -93,6 +117,58 @@
                     </java>
                     <lineEndings>UNIX</lineEndings>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.8</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/org/hisp/dhis/jsontree/JsonArray.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonArray.java
@@ -50,7 +50,7 @@ public interface JsonArray extends JsonCollection
      *
      * Note that this will neither check index nor element type.
      *
-     * @param index index to access (>= 0)
+     * @param index index to access (0 and above)
      * @param as assumed type of the element
      * @param <T> type of the returned element
      * @return element at the given index

--- a/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
@@ -156,6 +156,12 @@ public interface JsonObject extends JsonCollection
     }
 
     /**
+     * "Cast" and check against provided object shape.
+     *
+     * @param type expected object type
+     * @param <T> type check and of the result
+     * @return this node as the provided object type
+     *
      * @see #asObject(Class, boolean, String)
      */
     default <T extends JsonObject> T asObject( Class<T> type )
@@ -164,12 +170,16 @@ public interface JsonObject extends JsonCollection
     }
 
     /**
+     * "Cast" and check against provided object shape.
+     *
      * In contrast to {@link #as(Class)} this method does check that this object
      * {@link #exists()}, that it is indeed an object node and that it has all
      * {@link Expected} values expected for the provided object type.
      *
      * @param type expected object type
      * @param recursive true to apply the check to nested {@link JsonObject}s
+     * @param path currently checked root object (for recursion, start with
+     *        empty)
      * @param <T> type check and of the result
      * @return this node as the provided object type
      * @throws NoSuchElementException when this does not exist, is not an object


### PR DESCRIPTION
* Adds the necessary configuration to `pom.xml` to allow for deploying this project/artefact to the Sonatype Maven repository. Adds scm, issue management, distribution management. Adds required plugins for javadoc, source, nexus staging and gpg key generation.

* The gpg library is now required to be installed locally.

* Sets version to 0.1.0.

* The 0.1.0 version is now deployed to Sonatype, which syncs with Maven central.

* A new version can now be deployed with `mvn deploy`.