### PR TITLE
chore: JSON builder API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,74 +44,85 @@ Tree Navigation
 * and more of similar kind...
 
 Drilling down...
-```java
-JsonString str = root.getObject("a").getArray("b").getString(3)
-// or
-JsonString str = root.getString("a.b[3]")
-```
 
-Assertions using standard JUnit asserts
-```java
-JsonObject settings = GET( "/me/settings" ).content( HttpStatus.OK );
-
-assertTrue( settings.isObject() );
-assertFalse( settings.isEmpty() );
-assertTrue( settings.get( "keyMessageSmsNotification" ).exists() );
-assertEquals( "en", settings.getString( "keyUiLocale" ).string() );
-```
-Virtual tree: no exceptions before assert 🤩 
-
-Asserting a Schema or Shape
-```java
-assertTrue ( settings.isA( JsonSettings.class) );
-```
-Recursivly checks that all `@Expected` members of `JsonSettings` interface are present.
-
-## Advanced Features
-
-**Custom node types**
-```java
-public interface JsonPasswordValidation extends JsonObject
-{
-	default boolean isValidPassword()
-	{
-		return getBoolean( "isValidPassword" ).booleanValue();
-	}
-
-	default String getErrorMessage()
-	{
-		return getString( "errorMessage" ).string();
-	}
-}
-```
-```java
-JsonPasswordValidation result = POST( "/me/validatePassword", "text/plain:$ecrEt42" )
-    .content().as( JsonPasswordValidation.class );
-assertTrue( result.isValidPassword() );
-assertNull( result.getErrorMessage() );
-```
-
-**Asserting Structure**
-
-Annotate getters with `@Expected`
-```java
-JsonObject result = POST( "/me/validatePassword", "text/plain:$ecrEt42" ).content()
-assertTrue(result.isA(JsonPasswordValidation.class));
-// or
-JsonPasswordValidation result = POST( "/me/validatePassword", "text/plain:$ecrEt42" )
-    .content().asObject( JsonPasswordValidation.class );
-```
+    JsonString str=root.getObject("a").getArray("b").getString(3)
+    // or
+    JsonString str=root.getString("a.b[3]")
 
 Traversing actual tree to find nodes or manipulate it
+
 * `JsonValue#node()`: from virtual to actual JSON tree 🗱
 * `JsonObect#find`: return first matching `JsonValue`
 * `JsonNode#visit`: visit matching nodes
 * `JsonNode#find`: return first matching `JsonNode`
 * `JsonNode#count`: count matching nodes
 
+Assertions using standard JUnit asserts
+
+    JsonObject settings = GET("/me/settings").content(HttpStatus.OK);
+    
+    assertTrue(settings.isObject());
+    assertFalse(settings.isEmpty());
+    assertTrue(settings.get("keyMessageSmsNotification").exists());
+    assertEquals("en",settings.getString("keyUiLocale").string());
+
+Virtual tree: no exceptions before assert 🤩
+
+## Custom Node Types
+
+The `JsonValue` API can easily be extended with user defined types by simply declaring an interface with `default`
+methods.
+
 ```java
-JsonWebMessage message = assertWebMessage(...);
-JsonErrorReport error = message.find( JsonErrorReport.class,
-            report -> report.getErrorCode() == ErrorCode.E4031 );
-assertEquals("expected message", error.getMessage() );
+public interface JsonPasswordValidation extends JsonObject
+{
+    default boolean isValidPassword()
+    {
+        return getBoolean( "isValidPassword" ).booleanValue();
+    }
+
+    default String getErrorMessage()
+    {
+        return getString( "errorMessage" ).string();
+    }
+}
 ```
+
+Use `as` or `asObject` to "cast" a `JsonValue` to a custom type:
+
+    JsonValue jsonValue = fetchPasswordValidation();
+    JsonPasswordValidation result = jsonValue.as(JsonPasswordValidation.class );
+    assertTrue(result.isValidPassword());
+    assertNull(result.getErrorMessage());
+
+Asserting a Schema or Structure
+
+    assertTrue(settings.isA(JsonPasswordValidation.class));
+
+Recursively checks that all primitive members or members annotated with `@Expected` as defined by the `JsonSettings`
+interface are present.
+
+When `asObject` is used instead of `as` the structural check is done implicitly and fails with an exception should the
+actual JSON not match the expectations defined by the provided user defined interface.
+
+## Building or Streaming JSON
+
+The `JsonBuilder` API is used to:
+
+* create a `JsonNode` document (and from there a JSON `String`)
+* directly stream JSON to an output stream while it is built
+
+While it is an "append-only" API to support true streaming its use of lambda function arguments allows to compose the
+output in a convenient and flexible way.
+
+Ad-hoc creation of `JsonNode`:
+
+    JsonNode obj = JsonBuilder.createObject(
+        obj -> obj.addString( "name","value" ));
+    
+    String json = obj.getDeclaration();
+
+Directly writing JSON to an output stream:
+
+    JsonBuilder.streamObject( out, 
+        obj -> obj.addString( "name", "value" ) );

--- a/src/main/java/org/hisp/dhis/jsontree/JsonAppender.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonAppender.java
@@ -125,22 +125,28 @@ public class JsonAppender implements JsonBuilder, JsonObjectBuilder, JsonArrayBu
     }
 
     @Override
-    public JsonNode toObject( Consumer<JsonObjectBuilder> value )
+    public JsonNode toObject( Consumer<JsonObjectBuilder> obj )
     {
         beginLevel( '{' );
-        value.accept( this );
+        obj.accept( this );
         endLevel( '}' );
-        return new JsonDocument( toStr.get() ).get( "$" );
+        return toNode();
 
     }
 
     @Override
-    public JsonNode toArray( Consumer<JsonArrayBuilder> value )
+    public JsonNode toArray( Consumer<JsonArrayBuilder> arr )
     {
         beginLevel( '[' );
-        value.accept( this );
+        arr.accept( this );
         endLevel( ']' );
-        return new JsonDocument( toStr.get() ).get( "$" );
+        return toNode();
+    }
+
+    private JsonNode toNode()
+    {
+        String json = toStr.get();
+        return json == null ? null : new JsonDocument( json ).get( "$" );
     }
 
     /*

--- a/src/main/java/org/hisp/dhis/jsontree/JsonNode.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonNode.java
@@ -77,7 +77,7 @@ public interface JsonNode extends Serializable
     }
 
     /**
-     * Whether or not an array or object has no elements or members.
+     * Whether an array or object has no elements or members.
      *
      * This is preferable to calling {@link #value()} or {@link #members()} or
      * {@link #elements()} when emptiness is only property of interest as it

--- a/src/main/java/org/hisp/dhis/jsontree/JsonValue.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonValue.java
@@ -38,7 +38,7 @@ package org.hisp.dhis.jsontree;
  * <li>{@link JsonNumber}</li>
  * <li>{@link JsonBoolean}</li>
  * </ul>
- * In addition there is {@link JsonCollection} as a common base type of
+ * In addition, there is {@link JsonCollection} as a common base type of
  * {@link JsonObject} and {@link JsonArray} and {@link JsonPrimitive} as common
  * base type of {@link JsonString}, {@link JsonNumber} and {@link JsonBoolean}.
  *
@@ -64,6 +64,28 @@ package org.hisp.dhis.jsontree;
  */
 public interface JsonValue
 {
+    /**
+     * Lift an actual {@link JsonNode} tree to a virtual {@link JsonValue}.
+     *
+     * @param node non null
+     * @return the provided {@link JsonNode} as virtual {@link JsonValue}
+     */
+    static JsonValue of( JsonNode node )
+    {
+        return node == null ? JsonResponse.NULL : of( node.getDeclaration() );
+    }
+
+    /**
+     * View the provided JSON string as virtual lazy evaluated tree.
+     *
+     * @param json JSON string
+     * @return virtual JSON tree root {@link JsonValue}
+     */
+    static JsonValue of( String json )
+    {
+        return new JsonResponse( json );
+    }
+
     /**
      * A property exists when it is part of the JSON response. This means it can
      * be declared JSON {@code null}. Only a path that does not exist returns
@@ -110,8 +132,8 @@ public interface JsonValue
      * switched to any other type. Types here are just what we believe to be
      * true. They are only here to guide us, not assert existence.
      *
-     * Whether or not assumptions are actually true is determined when leaf
-     * values are accessed.
+     * Whether assumptions are actually true is determined when leaf values are
+     * accessed.
      *
      * @param as assumed value type
      * @param <T> value type returned

--- a/src/test/java/org/hisp/dhis/jsontree/JsonBuilderTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonBuilderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.jsontree;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+
+import org.junit.Test;
+
+/**
+ * Tests the static methods of the {@link JsonBuilder}.
+ *
+ * This is mostly to ensure the wiring is correct so the tests are not trying to
+ * cover different cases when it comes to JSON creation - they just want to
+ * cover different path of wiring.
+ *
+ * @author Jan Bernitt
+ */
+public class JsonBuilderTest
+{
+    @Test
+    public void testCreateObject()
+    {
+        assertEquals( "{\"foo\":[\"bar\"]}",
+            JsonBuilder.createObject( obj -> obj.addArray( "foo", "bar" ) )
+                .getDeclaration() );
+    }
+
+    @Test
+    public void testCreateArray()
+    {
+        assertEquals( "[42,\"42\",true]",
+            JsonBuilder.createArray( arr -> arr.addNumber( 42 ).addString( "42" ).addBoolean( true ) )
+                .getDeclaration() );
+    }
+
+    @Test
+    public void testStreamObject()
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        JsonBuilder.streamObject( out, obj -> obj.addArray( "foo", "bar" ) );
+        assertEquals( "{\"foo\":[\"bar\"]}", out.toString() );
+    }
+
+    @Test
+    public void testStreamArray()
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        JsonBuilder.streamArray( out, arr -> arr.addNumber( 42 ).addString( "42" ).addBoolean( true ) );
+        assertEquals( "[42,\"42\",true]", out.toString() );
+    }
+}

--- a/src/test/java/org/hisp/dhis/jsontree/JsonValueTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonValueTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.jsontree;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+/**
+ * Tests the static helpers of {@link JsonValue}.
+ *
+ * @author Jan Bernitt
+ */
+public class JsonValueTest
+{
+    @Test
+    public void testOfJsonNode()
+    {
+        JsonValue value = JsonValue.of( JsonBuilder.createObject( obj -> obj.addString( "foo", "bar" ) ) );
+        assertNotNull( value );
+        assertEquals( "{\"foo\":\"bar\"}", value.toString() );
+    }
+}


### PR DESCRIPTION
Adds some missing convenience methods to use the JSON builder API and updates the README to better reflect the stand alone library with its core features. 