### PR TITLE
feat: JsonValue view transformations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 hs_err_pid*
 
 target
+
+# IDE files
+.idea

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ which exposes all node types as `JsonNode`.
 
 | `JsonValue` API | `JsonNode` API |
 | --------------- | -------------- |
+| `JsonValue#node()` =>  | <= `JsonValue.of(node)` |
 | **virtual** 👻  | **actual** ☠️   |
 | high level abstraction | low level abstraction |
 | what we expect we got back | what we actually got back |
@@ -49,7 +50,7 @@ Drilling down...
     // or
     JsonString str=root.getString("a.b[3]")
 
-Traversing actual tree to find nodes or manipulate it
+Traversing **actual** tree to find nodes
 
 * `JsonValue#node()`: from virtual to actual JSON tree 🗱
 * `JsonObect#find`: return first matching `JsonValue`
@@ -126,3 +127,115 @@ Directly writing JSON to an output stream:
 
     JsonBuilder.streamObject( out, 
         obj -> obj.addString( "name", "value" ) );
+
+## Manipulating JSON Trees
+
+The `JsonNode` trees are effectively immutable tree structures. However, they
+can be "manipulated" returning a new changed tree root.
+
+To replace any type of node with a different node use `JsonNode#replaceWith`.
+The new JSON `String` provided is expected to be valid JSON. To add members to
+an object node `JsonNode#addMember` is used, again expecting value name and JSON
+value. Both return a new changed root.
+
+If only a subtree of an existing tree should be extracted
+use `JsonNode#extract();`
+
+**OBS!** This technique should be used with care it each changes produces a new
+tree that needs to be parsed again.
+
+## Searching JSON Trees
+
+As the `JsonValue` represents a virtual or expected tree the API to search this
+tree is quite limited as any search has to build upon the `JsonNode` API which
+reflects the actual tree.
+
+For convenience the subtree of a `JsonObject` can be searched for an object node
+that satisfies a particular shape and test `Predicate`:
+
+    JsonObject match = root.find(JsonPasswordValidation.class, obj -> true);
+
+The above example finds the first object in the subtree that successfully can
+be "cast" to a `JsonPasswordValidation`
+object, meaning it has all its `@Expected` members (same as
+calling `obj.isA(JsonPasswordValidation.class)` on each potential object in the
+subtree).
+
+    JsonObject match = root.find(JsonPasswordValidation.class, 
+        validation -> !validation.isValidPassword());
+
+In the second example the search is extended by an additional `Predicate`. Now
+the `match` is the first `JsonPasswordValidation` which has an invalid password.
+
+The `JsonObject#find` method builds upon the `JsonNode` API which offers a
+broader range of search capabilities.
+
+* `JsonNode#find`: find first match that satisfy both a
+  particular `JsonNodeType` and a `Predicate<JsonNode>`
+* `JsonNode#count`: count all matches that satisfy both a
+  particular `JsonNodeType` and `Predicate<JsonNode>`
+* `JsonNode#visit`: fully generic subtree visitor in form of
+  a `Consumer<JsonNode>`
+
+The downside of the `JsonNode` search API is that dealing with `JsonNode` is
+more cumbersome and can throw exceptions. Therefore, it can make sense to
+implement specific search methods similar to `JsonObject#find` in types that
+extend `JsonObject`.
+
+Searching for an element in a `JsonList` can be done using a number of methods:
+
+* `containsAll`: check if the list contains a subset
+* `contains`: check at least one matching element is contained
+* `containsUnique`: check that one and only one matching element is contained
+* `count`: count elements matching a `Predicate` test
+* `first`: find the first matching element
+
+These can be used with `JsonArray` as any array can be treated as list
+using `array.asList(JsonValue.class)`.
+
+Another way to test qualities of a `JsonList` is to use one of its `toList`
+methods to turn it into a `java.util.List`. The assumption is that the values in
+that target list should not be instances of `JsonValue` but "usual" java types.
+Therefore, any of the `toList` methods accepts a `Function` to transform
+the `JsonValue` elements into some java type. At the point of conversion the
+virtual tree is accessing the actual tree which means exceptions are possible.
+To mitigate this risk there are different variations of the `toList` method:
+
+* `toList(Function)`: map and expect all source values to exist, otherwise
+  throws exception
+* `toList(Function, Object)`: map and use provided default value in
+  case source element does not exist
+* `toListOfElementsThatExists(Function)`: map and skip those source elements
+  of the list that do not exist
+
+A reason for elements to not exist in an existing array are view
+transformations. For example if the original elements are objects and a member
+is extracted for the view not all object might have this member.
+
+## View-Transform JSON Trees
+
+While the actual `JsonNode` tree is immutable and never changed for any
+virtual `JsonValue` tree layered on top of it the virtual tree can be virtually
+transformed. This means looking at the same tree through a lens that maps the
+affected level to some other way to look at it. Usually this is used to 
+"de-objectify" elements or members by mapping to one of their members.
+
+Available view transformations are:
+
+* `JsonArray#viewAsList`: maps all array elements resulting in a list view
+* `JsonList#viewAsList`: maps all list elements resulting in a list view
+* `JsonMap#viewAsMap`: maps all map members resulting in a map view
+* `JsonObject#viewAsObject`: maps all object member values resulting in an
+  object view
+* `JsonMultiMap#viewAsMultiMap`: maps all values of the multimap lists
+  returning in a multimap view
+
+Given the list `[{"x":1},{"x":2}]` the view 
+
+    array.viewAsList(e -> e.asObject().getNumber("x"))
+
+would result in an effective value of `[1,2]`. Again, the underlying tree is not
+changed by this, just the view on top of it is transformed.
+
+Such transformation can be especially useful in combination with `toList` to
+extract a list of the values that can be compared to an expected list. 

--- a/src/main/java/org/hisp/dhis/jsontree/JsonArray.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonArray.java
@@ -36,15 +36,14 @@ import java.util.function.Function;
  * Represents a JSON array node.
  *
  * As all nodes are mere views or virtual index access will never throw an
- * {@link ArrayIndexOutOfBoundsException}. Whether or not an element at an index
- * exists is determined first when {@link JsonValue#exists()} or other value
- * accessing operations are performed on a node.
+ * {@link ArrayIndexOutOfBoundsException}. Whether an element at an index exists
+ * is determined first when {@link JsonValue#exists()} or other value accessing
+ * operations are performed on a node.
  *
  * @author Jan Bernitt
  */
 public interface JsonArray extends JsonCollection
 {
-
     /**
      * Index access to the array.
      *
@@ -52,10 +51,10 @@ public interface JsonArray extends JsonCollection
      *
      * @param index index to access (>= 0)
      * @param as assumed type of the element
-     * @param <T> type of the returned element
+     * @param <E> type of the returned element
      * @return element at the given index
      */
-    <T extends JsonValue> T get( int index, Class<T> as );
+    <E extends JsonValue> E get( int index, Class<E> as );
 
     /**
      * @return the array elements as a uniform list of {@link String}
@@ -126,5 +125,33 @@ public interface JsonArray extends JsonCollection
     default <E extends JsonValue> JsonMultiMap<E> getMultiMap( int index, Class<E> as )
     {
         return JsonCollection.asMultiMap( getObject( index ), as );
+    }
+
+    /**
+     * Maps this array to a lazy transformed list view where each element of the
+     * original array is transformed by the given function when accessed.
+     *
+     * This means the returned list always has same size as the original array.
+     *
+     * @param elementToX transformer function
+     * @param <V> type of the transformer output, elements of the list view
+     * @return a lazily transformed list view of this array
+     */
+    default <V extends JsonValue> JsonList<V> viewAsList( Function<JsonValue, V> elementToX )
+    {
+        final class JsonArrayView extends CollectionView<JsonArray> implements JsonList<V>
+        {
+            private JsonArrayView( JsonArray self )
+            {
+                super( self );
+            }
+
+            @Override
+            public V get( int index )
+            {
+                return elementToX.apply( viewed.get( index ) );
+            }
+        }
+        return new JsonArrayView( this );
     }
 }

--- a/src/main/java/org/hisp/dhis/jsontree/JsonDocument.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonDocument.java
@@ -202,7 +202,7 @@ public final class JsonDocument implements Serializable
         @Override
         public final void visit( JsonNodeType type, Consumer<JsonNode> visitor )
         {
-            if ( type == getType() )
+            if ( type == null || type == getType() )
             {
                 visitor.accept( this );
             }

--- a/src/main/java/org/hisp/dhis/jsontree/JsonList.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonList.java
@@ -27,9 +27,12 @@
  */
 package org.hisp.dhis.jsontree;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -56,11 +59,112 @@ public interface JsonList<E extends JsonValue> extends JsonCollection, Iterable<
      */
     E get( int index );
 
+    /**
+     * True, if this list contains all the values provided given each value of
+     * the list is transformed by the toValue function to access its comparable
+     * value.
+     *
+     * @param toValue convert list element to comparable value
+     * @param values set of expected value in no particular order
+     * @param <T> type of the values compared
+     * @return true if all values are found, otherwise false
+     */
+    default <T> boolean containsAll( Function<E, T> toValue, T... values )
+    {
+        return containsAll( toValue, Set.of( values ) );
+    }
+
+    /**
+     * True, if this list contains all the values provided given each value of
+     * the list is transformed by the toValue function to access its comparable
+     * value.
+     *
+     * @param toValue convert list element to comparable value
+     * @param values set of expected value in no particular order
+     * @param <T> type of the values compared
+     * @return true if all values are found, otherwise false
+     */
+    default <T> boolean containsAll( Function<E, T> toValue, Collection<T> values )
+    {
+        return count( toValue, values::contains ) == values.size();
+    }
+
+    /**
+     * Is there any value matching the test?
+     *
+     * @param toValue convert list element to comparable value
+     * @param test returns true, if equal (contained)
+     * @param <T> type of the values compared
+     * @return true if any value is found returning true for the test performed
+     */
+    default <T> boolean contains( Function<E, T> toValue, Predicate<T> test )
+    {
+        return count( toValue, test ) > 0;
+    }
+
+    /**
+     * Is there just one and only one value matching the test?
+     *
+     * @param toValue convert list element to comparable value
+     * @param test returns true, if equal (contained)
+     * @param <T> type of the values compared
+     * @return true if only one value is found returning true for the test
+     *         performed
+     */
+    default <T> boolean containsUnique( Function<E, T> toValue, Predicate<T> test )
+    {
+        return count( toValue, test ) == 1;
+    }
+
+    /**
+     * Counts the number of values in this list that match the test (return
+     * true).
+     *
+     * @param toValue convert list element to comparable value
+     * @param test returns true, if equal (contained)
+     * @param <T> type of the values compared
+     * @return number of elements matching the test
+     */
+    default <T> int count( Function<E, T> toValue, Predicate<T> test )
+    {
+        int c = 0;
+        for ( E e : this )
+        {
+            if ( test.test( toValue.apply( e ) ) )
+            {
+                c++;
+            }
+        }
+        return c;
+    }
+
+    /**
+     * Finds the first element of this list that matches the test criteria
+     * (returns true).
+     *
+     * If no such element is returned a non-existing element at index of size of
+     * this list is returned.
+     *
+     * @param test matcher to find the element
+     * @return the first matching element, or an element that does not exist
+     */
+    default E first( Predicate<E> test )
+    {
+        for ( E e : this )
+        {
+            if ( e.exists() && test.test( e ) )
+            {
+                return e;
+            }
+        }
+        return get( size() ); // we know this does not exist
+    }
+
     @Override
     default Iterator<E> iterator()
     {
         int size = size();
-        return new Iterator<E>()
+        return new Iterator<>()
         {
             int index = 0;
 
@@ -73,12 +177,11 @@ public interface JsonList<E extends JsonValue> extends JsonCollection, Iterable<
             @Override
             public E next()
             {
-                E e = get( index++ );
-                if ( !e.exists() )
+                if ( !hasNext() )
                 {
                     throw new NoSuchElementException();
                 }
-                return e;
+                return get( index++ );
             }
         };
     }
@@ -101,14 +204,85 @@ public interface JsonList<E extends JsonValue> extends JsonCollection, Iterable<
      * from a {@link JsonValue} to a plain value a mapper {@link Function} is
      * provided.
      *
-     * @param mapper maps from {@link JsonValue} to plain value
+     * @param toValue maps from {@link JsonValue} to plain value
      * @param <T> type of result list elements
      * @return this list mapped to a {@link List} of elements mapped by the
      *         provided mapper function from the {@link JsonValue}s of this
      *         {@link JsonList}.
+     * @throws java.util.NoSuchElementException in case a source element
+     *         {@link JsonValue} does not exist
+     *
+     * @see #toList(Function, Object)
      */
-    default <T> List<T> toList( Function<E, T> mapper )
+    default <T> List<T> toList( Function<E, T> toValue )
     {
-        return stream().map( mapper ).collect( Collectors.toList() );
+        return stream().map( toValue ).collect( Collectors.toList() );
+    }
+
+    /**
+     * Map list of {@link JsonValue}s to plain/simple values using a provided
+     * default value when the {@link JsonValue} does not exist.
+     *
+     * @param toValue maps from {@link JsonValue} to plain value
+     * @param whenNotExists value used when {@link JsonValue} does not
+     *        {@link JsonValue#exists()}
+     * @param <T> type of result list elements
+     * @return mapped list using the default in case a {@link JsonValue} in this
+     *         list does not exist
+     */
+    default <T> List<T> toList( Function<E, T> toValue, T whenNotExists )
+    {
+        return toList( e -> e.exists() ? toValue.apply( e ) : whenNotExists );
+    }
+
+    /**
+     * Unlike {@link #toList(Function)} which throws an exception should a
+     * source {@link JsonValue} not exist this method skips all elements that do
+     * not {@link JsonValue#exists()}.
+     *
+     * @param toValue maps from {@link JsonValue} to plain value
+     * @param <T> type of result list elements
+     * @return existing elements of this list mapped by the provided toValue
+     *         function
+     */
+    default <T> List<T> toListOfElementsThatExists( Function<E, T> toValue )
+    {
+        ArrayList<T> list = new ArrayList<>( size() );
+        for ( E e : this )
+        {
+            if ( e.exists() )
+            {
+                list.add( toValue.apply( e ) );
+            }
+        }
+        return list;
+    }
+
+    /**
+     * Maps this list to a lazy transformed list view where each element of the
+     * original list is transformed by the given function when accessed.
+     * <p>
+     * This means the returned list always has same size as the original list.
+     *
+     * @param elementToX transformer function
+     * @param <V> type of the transformer output, elements of the list view
+     * @return a lazily transformed list view of this list
+     */
+    default <V extends JsonValue> JsonList<V> viewAsList( Function<E, V> elementToX )
+    {
+        final class JsonListView extends CollectionView<JsonList<E>> implements JsonList<V>
+        {
+            private JsonListView( JsonList<E> self )
+            {
+                super( self );
+            }
+
+            @Override
+            public V get( int index )
+            {
+                return elementToX.apply( viewed.get( index ) );
+            }
+        }
+        return new JsonListView( this );
     }
 }

--- a/src/main/java/org/hisp/dhis/jsontree/JsonMap.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonMap.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.jsontree;
 
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * {@link JsonMap}s are a special form of a {@link JsonObject} where all
@@ -59,5 +60,34 @@ public interface JsonMap<E extends JsonValue> extends JsonCollection
     default Set<String> keys()
     {
         return node().members().keySet();
+    }
+
+    /**
+     * Maps this map's entry values to a lazy transformed map view where each
+     * entry value of the original map is transformed by the given function when
+     * accessed.
+     * <p>
+     * This means the returned map always has same size as the original map.
+     *
+     * @param memberToX transformer function
+     * @param <V> type of the transformer output, entries of the map view
+     * @return a lazily transformed map view of this map
+     */
+    default <V extends JsonValue> JsonMap<V> viewAsMap( Function<E, V> memberToX )
+    {
+        final class JsonMapView extends CollectionView<JsonMap<E>> implements JsonMap<V>
+        {
+            private JsonMapView( JsonMap<E> viewed )
+            {
+                super( viewed );
+            }
+
+            @Override
+            public V get( String key )
+            {
+                return memberToX.apply( viewed.get( key ) );
+            }
+        }
+        return new JsonMapView( this );
     }
 }

--- a/src/main/java/org/hisp/dhis/jsontree/JsonMultiMap.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonMultiMap.java
@@ -94,4 +94,35 @@ public interface JsonMultiMap<E extends JsonValue> extends JsonMap<JsonList<E>>
         }
         return res;
     }
+
+    /**
+     * Maps this multimap list elements to a lazy transformed view where each
+     * entry value of the original map is transformed by the given function when
+     * accessed.
+     * <p>
+     * This means the returned multimap always has same size as the original
+     * map.
+     *
+     * @param memberToX transformer function
+     * @param <V> type of the transformer output for list elements of each of
+     *        the map entry lists
+     * @return a lazily transformed multimap view of this multimap
+     */
+    default <V extends JsonValue> JsonMultiMap<V> viewAsMultiMap( Function<E, V> memberToX )
+    {
+        final class JsonMapView extends CollectionView<JsonMultiMap<E>> implements JsonMultiMap<V>
+        {
+            private JsonMapView( JsonMultiMap<E> viewed )
+            {
+                super( viewed );
+            }
+
+            @Override
+            public JsonList<V> get( String key )
+            {
+                return viewed.get( key ).viewAsList( memberToX );
+            }
+        }
+        return new JsonMapView( this );
+    }
 }

--- a/src/main/java/org/hisp/dhis/jsontree/JsonNode.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonNode.java
@@ -173,6 +173,17 @@ public interface JsonNode extends Serializable
     void visit( JsonNodeType type, Consumer<JsonNode> visitor );
 
     /**
+     * Visit subtree of this node including this node.
+     *
+     * @param visitor consumes all nodes in the subtree of this node (including
+     *        this node)
+     */
+    default void visit( Consumer<JsonNode> visitor )
+    {
+        visit( null, visitor );
+    }
+
+    /**
      * Searches for a node in this subtree that matches type and returns true
      * from the provided test.
      *

--- a/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
@@ -35,6 +35,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.hisp.dhis.jsontree.JsonDocument.JsonNodeType;
@@ -73,7 +74,10 @@ public interface JsonObject extends JsonCollection
      * @throws UnsupportedOperationException in case this value is not an JSON
      *         object
      */
-    boolean has( String... names );
+    default boolean has( String... names )
+    {
+        return stream( names ).allMatch( name -> get( name ).exists() );
+    }
 
     /**
      * Lists JSON object member names in order of declaration.
@@ -249,5 +253,35 @@ public interface JsonObject extends JsonCollection
         return !match.isPresent()
             ? JsonResponse.NULL.as( type )
             : new JsonResponse( match.get().getDeclaration() ).asObject( type );
+    }
+
+    /**
+     * Maps this object's members to a lazy transformed object view where each
+     * member value of the original object is transformed by the given function
+     * when accessed.
+     * <p>
+     * This means the returned object always has the same number of members as
+     * the original object.
+     *
+     * @param memberToX transformer function
+     * @param <V> type of the transformer output, members of the object view
+     * @return a lazily transformed object view of this object
+     */
+    default <V extends JsonValue> JsonObject viewAsObject( Function<JsonValue, V> memberToX )
+    {
+        final class JsonObjectView extends CollectionView<JsonObject> implements JsonObject
+        {
+            private JsonObjectView( JsonObject viewed )
+            {
+                super( viewed );
+            }
+
+            @Override
+            public <T extends JsonValue> T get( String name, Class<T> as )
+            {
+                return memberToX.apply( viewed.get( name ) ).as( as );
+            }
+        }
+        return new JsonObjectView( this );
     }
 }

--- a/src/main/java/org/hisp/dhis/jsontree/JsonResponse.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonResponse.java
@@ -194,9 +194,9 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
     @Override
     public boolean has( String... names )
     {
-        return value( JsonNodeType.OBJECT,
+        return Boolean.TRUE.equals( value( JsonNodeType.OBJECT,
             node -> node.members().keySet().containsAll( Arrays.asList( names ) ),
-            ex -> false );
+            ex -> false ) );
     }
 
     @Override

--- a/src/main/java/org/hisp/dhis/jsontree/JsonValue.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonValue.java
@@ -83,7 +83,7 @@ public interface JsonValue
      */
     static JsonValue of( String json )
     {
-        return new JsonResponse( json );
+        return json == null || "null".equals( json ) ? JsonResponse.NULL : new JsonResponse( json );
     }
 
     /**
@@ -141,6 +141,15 @@ public interface JsonValue
      *         wrapped as the provided type or literally cast.
      */
     <T extends JsonValue> T as( Class<T> as );
+
+    /**
+     * @return This value as {@link JsonObject} (same as
+     *         {@code as(JsonObject.class)})
+     */
+    default JsonObject asObject()
+    {
+        return as( JsonObject.class );
+    }
 
     /**
      * This value as a list of uniform elements (view on JSON array).


### PR DESCRIPTION
### Summary
Adds lazy evaluated views to the `JsonValue` as was well as `toList` method variants that can handle non existing list elements without throwing exceptions. In combination these new API methods target to ease the extraction of values that would be used in an assert.

Also `JsonList` got extended with `contains`, `containsAll`, `containsUnique`, `count` and `first` methods to allow easier assertions on the existence of elements that match a certain test `Predicate`. 

This set of features was motivated by actual cases in dhis2-core test suite where the API felt cumbersome to use to formulate the assert. The pattern that was difficult often showed a lack of an exact path that could be extracted, often because the value that should the checked could have been any of the elements of a collection.

### Other Improvements
* `JsonNode#visit` now also can be called with `null` for the `JsonNodeType` to mean _any_ of the types. This is made accessible by new method `void visit( Consumer<JsonNode> visitor );`.
* `JsonObject#has` now provides a default implementation so views do not have to implement it
* `JsonList#iterate` (which is central to many utility methods) does no longer demand existence. This was a confusion and should never have been the case. 

### Documentation
The README was updated to summarise the new capabilities.

