### PR TITLE
feat: JSON to POJO mapping [DHIS2-13378]

### DIFF
--- a/src/main/java/org/hisp/dhis/jsontree/JsonDate.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonDate.java
@@ -27,7 +27,9 @@
  */
 package org.hisp.dhis.jsontree;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
 /**
@@ -43,5 +45,15 @@ public interface JsonDate extends JsonString
     default LocalDateTime date()
     {
         return parsed( str -> LocalDateTime.parse( str, DateTimeFormatter.ISO_LOCAL_DATE_TIME ) );
+    }
+
+    default LocalDate dateOnly()
+    {
+        return parsed( str -> LocalDate.parse( str, DateTimeFormatter.ISO_LOCAL_DATE ) );
+    }
+
+    default LocalTime timeOnly()
+    {
+        return parsed( str -> LocalTime.parse( str, DateTimeFormatter.ISO_LOCAL_TIME ) );
     }
 }

--- a/src/main/java/org/hisp/dhis/jsontree/JsonDocument.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonDocument.java
@@ -259,7 +259,7 @@ public final class JsonDocument implements Serializable
         }
 
         @Override
-        public JsonNode addMember( String name, String value )
+        public final JsonNode addMember( String name, String value )
         {
             if ( getType() != JsonNodeType.OBJECT )
             {

--- a/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
@@ -52,7 +52,6 @@ import org.hisp.dhis.jsontree.JsonDocument.JsonNodeType;
  */
 public interface JsonObject extends JsonCollection
 {
-
     /**
      * Name access to object fields.
      *

--- a/src/main/java/org/hisp/dhis/jsontree/JsonTypedAccess.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonTypedAccess.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.jsontree;
+
+import static java.util.Spliterators.spliteratorUnknownSize;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.net.URL;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Standard implementation of the {@link JsonTypedAccessStore}.
+ * <p>
+ * On top of the {@link JsonGenericTypedAccessor}s that were added it
+ * automatically creates and adds an accessor for any {@code enum} and any
+ * subtype of {@link JsonValue} when it is resolved via
+ * {@link #accessor(Class)}.
+ *
+ * @author Jan Bernitt
+ * @since 0.4
+ */
+public final class JsonTypedAccess implements JsonTypedAccessStore
+{
+    public static final JsonTypedAccess GLOBAL = new JsonTypedAccess().init();
+
+    private final Map<Class<?>, JsonGenericTypedAccessor<?>> byResultType = new ConcurrentHashMap<>();
+
+    @Override
+    @SuppressWarnings( "unchecked" )
+    public <T> JsonGenericTypedAccessor<T> accessor( Class<T> type )
+    {
+        JsonGenericTypedAccessor<T> res = (JsonGenericTypedAccessor<T>) byResultType.get( type );
+        if ( type.isEnum() )
+        {
+            // automatically provide enum mapping
+            return (JsonGenericTypedAccessor<T>) byResultType.get( Enum.class );
+        }
+        if ( res == null && JsonValue.class.isAssignableFrom( type ) )
+        {
+            // automatically provide JsonValue subtype mapping
+            return (JsonGenericTypedAccessor<T>) byResultType.get( JsonValue.class );
+        }
+        return res;
+    }
+
+    public <T> JsonTypedAccess add( Class<T> returnType, JsonTypedAccessor<T> accessor )
+    {
+        byResultType.put( returnType, accessor );
+        return this;
+    }
+
+    public <T> JsonTypedAccess add( Class<T> returnType, JsonGenericTypedAccessor<T> accessor )
+    {
+        byResultType.put( returnType, accessor );
+        return this;
+    }
+
+    public JsonTypedAccess init()
+    {
+        return add( String.class, ( obj, name ) -> obj.getString( name ).string() )
+            .add( boolean.class, ( obj, name ) -> obj.getBoolean( name ).booleanValue() )
+            .add( char.class, JsonTypedAccess::accessChar )
+            .add( int.class, ( obj, name ) -> obj.getNumber( name ).intValue() )
+            .add( long.class, ( obj, name ) -> obj.getNumber( name ).longValue() )
+            .add( float.class, ( obj, name ) -> obj.getNumber( name ).floatValue() )
+            .add( double.class, ( obj, name ) -> obj.getNumber( name ).doubleValue() )
+            .add( Boolean.class, ( obj, name ) -> obj.getBoolean( name ).bool() )
+            .add( Character.class, ( obj, name ) -> obj.getString( name ).parsed( str -> str.charAt( 0 ) ) )
+            .add( Integer.class, ( obj, name ) -> orNull( obj.getNumber( name ).number(), Number::intValue ) )
+            .add( Long.class, ( obj, name ) -> orNull( obj.getNumber( name ).number(), Number::longValue ) )
+            .add( Float.class, ( obj, name ) -> orNull( obj.getNumber( name ).number(), Number::floatValue ) )
+            .add( Double.class, ( obj, name ) -> orNull( obj.getNumber( name ).number(), Number::doubleValue ) )
+            .add( Number.class, ( obj, name ) -> obj.getNumber( name ).number() )
+            .add( URL.class, ( obj, name ) -> obj.get( name, JsonURL.class ).url() )
+            .add( UUID.class, ( obj, name ) -> obj.getString( name ).parsed( UUID::fromString ) )
+            .add( LocalDateTime.class, ( obj, name ) -> obj.get( name, JsonDate.class ).date() )
+            .add( LocalDate.class, ( obj, name ) -> obj.get( name, JsonDate.class ).dateOnly() )
+            .add( LocalTime.class, ( obj, name ) -> obj.get( name, JsonDate.class ).timeOnly() )
+            .add( Date.class, JsonTypedAccess::accessDate )
+
+            // JSON generic types
+            .add( JsonList.class,
+                ( obj, name, to, store ) -> obj.getList( name, extractJsonValueTypeParameter( to, 0 ) ) )
+            .add( JsonMap.class,
+                ( obj, name, to, store ) -> obj.getMap( name, extractJsonValueTypeParameter( to, 0 ) ) )
+            .add( JsonMultiMap.class,
+                ( obj, name, to, store ) -> obj.getMultiMap( name, extractJsonValueTypeParameter( to, 0 ) ) )
+
+            // JDK generic types
+            .add( List.class, JsonTypedAccess::accessList )
+            .add( Set.class, JsonTypedAccess::accessSet )
+            .add( Map.class, JsonTypedAccess::accessMap )
+            .add( Stream.class, JsonTypedAccess::accessStream )
+            .add( Optional.class, JsonTypedAccess::accessOptional )
+
+            // type-sets
+            .add( Enum.class, ( obj, name, to, store ) -> obj.getString( name ).parsed(
+                str -> asEnumConstant( getRawType( to, Enum.class ), str ) ) )
+            .add( JsonValue.class,
+                ( obj, name, to, store ) -> obj.get( name ).as( getRawType( to, JsonValue.class ) ) );
+    }
+
+    private static <A, B> B orNull( A a, Function<A, B> f )
+    {
+        return a == null ? null : f.apply( a );
+    }
+
+    private static char accessChar( JsonObject obj, String path )
+    {
+        String str = obj.getString( path ).string();
+        if ( str == null || str.isEmpty() )
+        {
+            throw new NoSuchElementException( "No character for property " + path );
+        }
+        return str.charAt( 0 );
+    }
+
+    public static Date accessDate( JsonObject obj, String path )
+    {
+        JsonValue date = obj.get( path );
+        if ( date.isUndefined() )
+        {
+            return null;
+        }
+        if ( date.node().getType() == JsonDocument.JsonNodeType.NUMBER )
+        {
+            return new Date( date.as( JsonNumber.class ).longValue() );
+        }
+        return Date.from( LocalDateTime.parse( date.as( JsonString.class ).string() ).toInstant( ZoneOffset.UTC ) );
+    }
+
+    public static Optional<?> accessOptional( JsonObject from, String path, Type to, JsonTypedAccessStore store )
+    {
+        JsonValue v = from.get( path );
+        if ( v.isUndefined() )
+        {
+            return Optional.empty();
+        }
+        Type valueType = extractTypeParameter( to, 0 );
+        JsonGenericTypedAccessor<?> accessor = store.accessor( getRawType( valueType ) );
+        return Optional.ofNullable( accessor.access( from, path, valueType, store ) );
+    }
+
+    /**
+     * Accessors always assume to work relative to a parent object. Therefore,
+     * when accessing list elements the resolution is not using the list as root
+     * but the object that contains the list.
+     */
+    @SuppressWarnings( { "java:S1168", "java:S1452" } )
+    public static List<?> accessList( JsonObject from, String path, Type to, JsonTypedAccessStore store )
+    {
+        JsonList<?> list = from.getList( path, JsonValue.class );
+        if ( list.isUndefined() )
+        {
+            return null;
+        }
+        if ( list.isEmpty() )
+        {
+            return List.of();
+        }
+        Type elementType = extractTypeParameter( to, 0 );
+        JsonGenericTypedAccessor<?> elementAccess = store.accessor( getRawType( elementType ) );
+        int size = list.size();
+        List<Object> res = new ArrayList<>( size );
+        for ( int i = 0; i < size; i++ )
+        {
+            res.add( elementAccess.access( from, path + "[" + i + "]", elementType, store ) );
+        }
+        return res;
+    }
+
+    @SuppressWarnings( "java:S1452" )
+    public static Set<?> accessSet( JsonObject from, String path, Type to, JsonTypedAccessStore store )
+    {
+        List<?> list = accessList( from, path, to, store );
+        return list == null ? null : new HashSet<>( list );
+    }
+
+    @SuppressWarnings( { "java:S1168", "java:S1452" } )
+    public static Map<?, ?> accessMap( JsonObject from, String path, Type to, JsonTypedAccessStore store )
+    {
+        JsonObject map = from.getObject( path );
+        if ( map.isUndefined() )
+        {
+            return null;
+        }
+        if ( map.isEmpty() )
+        {
+            return Map.of();
+        }
+        Type valueType = extractTypeParameter( to, 1 );
+        JsonGenericTypedAccessor<?> valueAccess = store.accessor( getRawType( valueType ) );
+        Class<?> rawKeyType = getRawType( extractTypeParameter( to, 0 ) );
+        Function<String, Object> toKey = getKeyMapper( rawKeyType );
+        @SuppressWarnings( { "rawtypes", "unchecked" } )
+        Map<Object, Object> res = rawKeyType.isEnum() ? new EnumMap( rawKeyType ) : new HashMap<>();
+        for ( String member : map.names() )
+        {
+            res.put( toKey.apply( member ), valueAccess.access( map, member, valueType, store ) );
+        }
+        return res;
+    }
+
+    public static Stream<?> accessStream( JsonObject from, String path, Type to, JsonTypedAccessStore store )
+    {
+        JsonList<?> seq = from.getList( path, JsonValue.class );
+        if ( seq.isUndefined() )
+        {
+            return Stream.empty();
+        }
+        int size = seq.size();
+        Type elementType = extractTypeParameter( to, 0 );
+        JsonGenericTypedAccessor<?> elementAccess = store.accessor( getRawType( elementType ) );
+        Iterator<?> iter = new Iterator<Object>()
+        {
+            int i = 0;
+
+            @Override
+            public boolean hasNext()
+            {
+                return i < size;
+            }
+
+            @Override
+            public Object next()
+            {
+                if ( !hasNext() )
+                {
+                    throw new NoSuchElementException();
+                }
+                Object value = elementAccess.access( from, path + "[" + i + "]", elementType, store );
+                i++;
+                return value;
+            }
+        };
+        return StreamSupport.stream( spliteratorUnknownSize( iter, Spliterator.ORDERED ), false );
+    }
+
+    /**
+     * Map keys are really object member names and as such not values so
+     * accessors cannot be used to map them. Therefore, a handful of types are
+     * supported explicitly.
+     */
+    private static Function<String, Object> getKeyMapper( Class<?> rawKeyType )
+    {
+        if ( rawKeyType.isEnum() )
+        {
+            return key -> asEnumConstant( rawKeyType, key );
+        }
+        if ( String.class == rawKeyType )
+        {
+            return key -> key;
+        }
+        if ( Integer.class == rawKeyType )
+        {
+            return Integer::parseInt;
+        }
+        if ( Long.class == rawKeyType )
+        {
+            return Long::parseLong;
+        }
+        // any other number as long as Double works
+        if ( rawKeyType.isAssignableFrom( Double.class ) )
+        {
+            return Double::parseDouble;
+        }
+        if ( Character.class == rawKeyType )
+        {
+            return str -> str.charAt( 0 );
+        }
+        if ( Boolean.class == rawKeyType )
+        {
+            return Boolean::getBoolean;
+        }
+        throw new UnsupportedOperationException( "Unsupported map key type: " + rawKeyType );
+    }
+
+    public static Class<?> getRawType( Type type )
+    {
+        return getRawType( type, Object.class );
+    }
+
+    @SuppressWarnings( { "unchecked", "unused" } )
+    public static <T> Class<? extends T> getRawType( Type type, Class<T> base )
+    {
+        return (Class<T>) (type instanceof ParameterizedType
+            ? ((ParameterizedType) type).getRawType()
+            : type);
+    }
+
+    public static Type extractTypeParameter( Type from, int n )
+    {
+        return ((ParameterizedType) from).getActualTypeArguments()[n];
+    }
+
+    public static Class<? extends JsonValue> extractJsonValueTypeParameter( Type from, int n )
+    {
+        return getRawType( extractTypeParameter( from, n ), JsonValue.class );
+    }
+
+    @SuppressWarnings( { "rawtypes", "unchecked" } )
+    private static Enum<?> asEnumConstant( Class type, String str )
+    {
+        return Enum.valueOf( type, str );
+    }
+}

--- a/src/main/java/org/hisp/dhis/jsontree/JsonTypedAccessStore.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonTypedAccessStore.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.jsontree;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+/**
+ * The {@link JsonTypedAccessStore} is a registry for accessor functions.
+ *
+ * These come in a simple form {@link JsonTypedAccessor} for non-generic types,
+ * and a generic form {@link JsonGenericTypedAccessor} for more complicated
+ * types.
+ *
+ * Conceptually accessors are the POJO "mappers" of this library. Just that
+ * instead of using POJOs data structures are defined by their "getters" in an
+ * interface. The accessors then bridge the gap between the view the generic
+ * JSON tree provided in form of {@link JsonValue}s and the non-JSON java types
+ * returned by getters.
+ *
+ * While they "map" values this mapping takes place on access only. Everything
+ * before that is just as virtual (a view) as the {@link JsonValue} tree.
+ *
+ * One could also think of accessors as "automatic" implementation of an
+ * abstract method as if it became a default method in an interface. The
+ * "implementation" here is derived from the return type of the method. Each
+ * accessor knows how to access and map to a particular java tye. The store then
+ * contains the set of known java target types and their way to access them
+ * given a {@link JsonValue} tree.
+ *
+ * @author Jan Bernitt
+ * @since 0.4
+ */
+public interface JsonTypedAccessStore
+{
+    /**
+     * A function that given a parent object knows how to access a value at a
+     * certain path as a certain type.
+     *
+     * @param <T> the result type
+     */
+    @FunctionalInterface
+    interface JsonGenericTypedAccessor<T>
+    {
+        /**
+         * Accesses value the path as the target type.
+         *
+         * @param from the parent object containing the value at path
+         * @param path path to access the value
+         * @param to fully generic target type for the value of type {@code T}
+         * @param store in case further conversions are needed
+         * @return the value at path converted to target type
+         */
+        T access( JsonObject from, String path, Type to, JsonTypedAccessStore store );
+    }
+
+    /**
+     * A simplified version of a {@link JsonGenericTypedAccessor} that only
+     * requires a parent and a path.
+     *
+     * This usually is sufficient for simple Java types like strings, numbers
+     * and so forth.
+     *
+     * @param <T> the result type
+     */
+    @FunctionalInterface
+    interface JsonTypedAccessor<T> extends JsonGenericTypedAccessor<T>
+    {
+        /**
+         * Accesses value the path as the type implicitly assumed by this
+         * accessor.
+         *
+         * @param from the parent object containing that value at path
+         * @param path path to access the value
+         * @return the value at path with the type implicitly assumed by this
+         *         accessor.
+         */
+        T access( JsonObject from, String path );
+
+        @Override
+        default T access( JsonObject from, String path, Type to, JsonTypedAccessStore store )
+        {
+            return access( from, path );
+        }
+    }
+
+    /**
+     * Yields the accessor to use for the provided raw type.
+     *
+     * @param type the target type of access, if generic {@link Type} is a
+     *        {@link ParameterizedType} this should be the raw type
+     * @return the accessor to use, or {@code null} if no accessor is known for
+     *         the given type
+     * @param <T> type of the value provided by the returned accessor
+     */
+    <T> JsonGenericTypedAccessor<T> accessor( Class<T> type );
+
+}

--- a/src/test/java/org/hisp/dhis/jsontree/JsonTypedAccessTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonTypedAccessTest.java
@@ -1,0 +1,555 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.jsontree;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.TextStyle;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+/**
+ * Tests the {@link JsonTypedAccessStore} implementation {@link JsonTypedAccess}
+ * by using it via {@link JsonResponse} (it is the default implementation).
+ *
+ * @author Jan Bernitt
+ */
+public class JsonTypedAccessTest
+{
+    interface PrimitivesBean extends JsonObject
+    {
+        int aInt();
+
+        Integer aBigInteger();
+
+        int aInt( int v );
+
+        Integer aBigInteger( Integer v );
+
+        long aLong();
+
+        Long aBigLong();
+
+        long aLong( long v );
+
+        Long aBigLong( Long v );
+
+        float aFloat();
+
+        Float aBigFloat();
+
+        float aFloat( float v );
+
+        Float aBigFloat( Float v );
+
+        double aDouble();
+
+        Double aBigDouble();
+
+        double aDouble( double v );
+
+        Double aBigDouble( Double v );
+
+        boolean aBoolean();
+
+        Boolean aBigBoolean();
+
+        boolean aBoolean( boolean v );
+
+        Boolean aBigBoolean( Boolean v );
+
+        char aChar();
+
+        Character aBigCharacter();
+
+        char aChar( char v );
+
+        Character aBigCharacter( Character v );
+
+        String aString();
+
+        String aString( String v );
+
+        TextStyle aEnum();
+
+        TextStyle aEnum( TextStyle v );
+    }
+
+    @Test
+    public void testAccess_Integer()
+    {
+        PrimitivesBean obj = createJSON( "{'aInt':42, 'aBigInteger': -13}" ).as( PrimitivesBean.class );
+        assertEquals( 42, obj.aInt() );
+        assertEquals( 42, obj.aInt( 8 ) );
+        assertEquals( Integer.valueOf( -13 ), obj.aBigInteger() );
+        assertEquals( Integer.valueOf( -13 ), obj.aBigInteger( 22 ) );
+    }
+
+    @Test
+    public void testAccess_IntegerNonExistent()
+    {
+        PrimitivesBean obj = createJSON( "{}" ).as( PrimitivesBean.class );
+        assertThrows( NoSuchElementException.class, obj::aInt );
+        assertEquals( 8, obj.aInt( 8 ) );
+        assertNull( obj.aBigInteger() );
+        assertEquals( Integer.valueOf( 22 ), obj.aBigInteger( 22 ) );
+    }
+
+    @Test
+    public void testAccess_Long()
+    {
+        PrimitivesBean obj = createJSON( "{'aLong':42, 'aBigLong': -13}" ).as( PrimitivesBean.class );
+        assertEquals( 42L, obj.aLong() );
+        assertEquals( 42L, obj.aLong( 8 ) );
+        assertEquals( Long.valueOf( -13 ), obj.aBigLong() );
+        assertEquals( Long.valueOf( -13 ), obj.aBigLong( 22L ) );
+    }
+
+    @Test
+    public void testAccess_LongNonExistent()
+    {
+        PrimitivesBean obj = createJSON( "{}" ).as( PrimitivesBean.class );
+        assertThrows( NoSuchElementException.class, obj::aLong );
+        assertEquals( 8L, obj.aLong( 8L ) );
+        assertNull( obj.aBigLong() );
+        assertEquals( Long.valueOf( 22 ), obj.aBigLong( 22L ) );
+    }
+
+    @Test
+    public void testAccess_Float()
+    {
+        PrimitivesBean obj = createJSON( "{'aFloat':4.2, 'aBigFloat': -1.3}" ).as( PrimitivesBean.class );
+        assertEquals( 4.2f, obj.aFloat(), 0.01f );
+        assertEquals( 4.2f, obj.aFloat( 8f ), 0.01f );
+        assertEquals( Float.valueOf( -1.3f ), obj.aBigFloat() );
+        assertEquals( Float.valueOf( -1.3f ), obj.aBigFloat( 22f ) );
+    }
+
+    @Test
+    public void testAccess_FloatNonExistent()
+    {
+        PrimitivesBean obj = createJSON( "{}" ).as( PrimitivesBean.class );
+        assertThrows( NoSuchElementException.class, obj::aFloat );
+        assertEquals( 8f, obj.aFloat( 8f ), 0.01f );
+        assertNull( obj.aBigFloat() );
+        assertEquals( Float.valueOf( 22f ), obj.aBigFloat( 22f ) );
+    }
+
+    @Test
+    public void testAccess_Double()
+    {
+        PrimitivesBean obj = createJSON( "{'aDouble':4.2, 'aBigDouble': -1.3}" ).as( PrimitivesBean.class );
+        assertEquals( 4.2d, obj.aDouble(), 0.01d );
+        assertEquals( 4.2d, obj.aDouble( 8d ), 0.01d );
+        assertEquals( Double.valueOf( -1.3d ), obj.aBigDouble() );
+        assertEquals( Double.valueOf( -1.3d ), obj.aBigDouble( 22d ) );
+    }
+
+    @Test
+    public void testAccess_DoubleNonExistent()
+    {
+        PrimitivesBean obj = createJSON( "{}" ).as( PrimitivesBean.class );
+        assertThrows( NoSuchElementException.class, obj::aDouble );
+        assertEquals( 8d, obj.aDouble( 8d ), 0.01d );
+        assertNull( obj.aBigDouble() );
+        assertEquals( Double.valueOf( 22d ), obj.aBigDouble( 22d ) );
+    }
+
+    @Test
+    public void testAccess_Char()
+    {
+        PrimitivesBean obj = createJSON( "{'aChar':'a', 'aBigCharacter': 'B'}" ).as( PrimitivesBean.class );
+        assertEquals( 'a', obj.aChar() );
+        assertEquals( 'a', obj.aChar( '8' ) );
+        assertEquals( Character.valueOf( 'B' ), obj.aBigCharacter() );
+        assertEquals( Character.valueOf( 'B' ), obj.aBigCharacter( 'X' ) );
+    }
+
+    @Test
+    public void testAccess_CharNonExistent()
+    {
+        PrimitivesBean obj = createJSON( "{}" ).as( PrimitivesBean.class );
+        assertThrows( NoSuchElementException.class, obj::aChar );
+        assertEquals( 'x', obj.aChar( 'x' ) );
+        assertNull( obj.aBigCharacter() );
+        assertEquals( Character.valueOf( 'Y' ), obj.aBigCharacter( 'Y' ) );
+    }
+
+    @Test
+    public void testAccess_Boolean()
+    {
+        PrimitivesBean obj = createJSON( "{'aBoolean':true, 'aBigBoolean': true}" ).as( PrimitivesBean.class );
+        assertTrue( obj.aBoolean() );
+        assertTrue( obj.aBoolean( false ) );
+        assertEquals( Boolean.TRUE, obj.aBigBoolean() );
+        assertEquals( Boolean.TRUE, obj.aBigBoolean( false ) );
+    }
+
+    @Test
+    public void testAccess_BooleanNonExistent()
+    {
+        PrimitivesBean obj = createJSON( "{}" ).as( PrimitivesBean.class );
+        assertThrows( NoSuchElementException.class, obj::aBoolean );
+        assertTrue( obj.aBoolean( true ) );
+        assertNull( obj.aBigBoolean() );
+        assertEquals( Boolean.TRUE, obj.aBigBoolean( true ) );
+    }
+
+    @Test
+    public void testAccess_String()
+    {
+        PrimitivesBean obj = createJSON( "{'aString': 'hello'}" ).as( PrimitivesBean.class );
+        assertEquals( "hello", obj.aString() );
+        assertEquals( "hello", obj.aString( "x" ) );
+    }
+
+    @Test
+    public void testAccess_StringNonExistent()
+    {
+        PrimitivesBean obj = createJSON( "{}" ).as( PrimitivesBean.class );
+        assertNull( obj.aString() );
+        assertEquals( "x", obj.aString( "x" ) );
+    }
+
+    @Test
+    public void testAccess_Enum()
+    {
+        PrimitivesBean obj = createJSON( "{'aEnum': 'FULL'}" ).as( PrimitivesBean.class );
+        assertEquals( TextStyle.FULL, obj.aEnum() );
+        assertEquals( TextStyle.FULL, obj.aEnum( TextStyle.SHORT ) );
+    }
+
+    @Test
+    public void testAccess_EnumNonExistent()
+    {
+        PrimitivesBean obj = createJSON( "{}" ).as( PrimitivesBean.class );
+        assertNull( obj.aEnum() );
+        assertEquals( TextStyle.SHORT, obj.aEnum( TextStyle.SHORT ) );
+    }
+
+    interface NestedBean extends JsonObject
+    {
+        int a();
+
+        NestedBean getB();
+
+        JsonList<NestedBean> list();
+    }
+
+    @Test
+    public void testAccess_ExtendedObject()
+    {
+        NestedBean obj = createJSON( "{'a':1, 'b': {'a':2}}" ).as( NestedBean.class );
+        assertEquals( 1, obj.a() );
+        assertEquals( 2, obj.getB().a() );
+    }
+
+    @Test
+    public void testAccess_ExtendedObjectList()
+    {
+        NestedBean obj = createJSON( "{'list': [{'a':3}, {'a':4, 'list': [{'a':5}]}]}" ).as( NestedBean.class );
+        assertEquals( List.of( 3, 4 ),
+            obj.list().viewAsList( e -> e.getNumber( "a" ) ).toList( JsonNumber::intValue ) );
+        assertEquals( 5, obj.list().get( 1 ).list().get( 0 ).a() );
+    }
+
+    interface DateBean extends JsonObject
+    {
+        JsonDate aNode();
+
+        LocalDateTime aLocalDateTime();
+
+        Date aDate();
+    }
+
+    @Test
+    public void testAccess_DateNode()
+    {
+        DateBean bean = createJSON( "{'aNode':'2000-01-01T00:00'}" ).as( DateBean.class );
+        assertEquals( LocalDate.of( 2000, 1, 1 ).atStartOfDay(), bean.aNode().date() );
+    }
+
+    @Test
+    public void testAccess_DateLocalDateTime()
+    {
+        DateBean bean = createJSON( "{'aLocalDateTime':'2000-01-01T00:00'}" ).as( DateBean.class );
+        assertEquals( LocalDate.of( 2000, 1, 1 ).atStartOfDay(), bean.aLocalDateTime() );
+    }
+
+    @Test
+    public void testAccess_Date()
+    {
+        DateBean bean = createJSON( "{'aDate':'2000-01-01T00:00'}" ).as( DateBean.class );
+        Date expected = Date.from( LocalDate.of( 2000, 1, 1 ).atStartOfDay().toInstant( ZoneOffset.UTC ) );
+        assertEquals( expected, bean.aDate() );
+    }
+
+    @Test
+    public void testAccess_DateTimestamp()
+    {
+        DateBean bean = createJSON( "{'aDate':946684800000}" ).as( DateBean.class );
+        Date expected = Date.from( LocalDate.of( 2000, 1, 1 ).atStartOfDay().toInstant( ZoneOffset.UTC ) );
+        assertEquals( expected, bean.aDate() );
+    }
+
+    interface ListBean extends JsonObject
+    {
+        List<String> names();
+
+        List<String> names( List<String> v );
+
+        List<Integer> ages();
+
+        List<List<Boolean>> flags();
+
+        List<ListBean> recursive();
+    }
+
+    @Test
+    public void testAccess_ListNull()
+    {
+        assertNull( createJSON( "{}" ).as( ListBean.class ).names() );
+        assertNull( createJSON( "{'names':null}" ).as( ListBean.class ).names() );
+        assertEquals( List.of(), createJSON( "{}" ).as( ListBean.class ).names( List.of() ) );
+    }
+
+    @Test
+    public void testAccess_ListEmpty()
+    {
+        assertEquals( List.of(), createJSON( "{'names':[]}" ).as( ListBean.class ).names() );
+    }
+
+    @Test
+    public void testAccess_ListString()
+    {
+        assertEquals( List.of( "foo", "bar" ), createJSON( "{'names':['foo','bar']}" ).as( ListBean.class ).names() );
+    }
+
+    @Test
+    public void testAccess_ListInteger()
+    {
+        assertEquals( List.of( 1, 2, 3 ), createJSON( "{'ages':[1,2,3]}" ).as( ListBean.class ).ages() );
+    }
+
+    @Test
+    public void testAccess_ListListBoolean()
+    {
+        ListBean bean = createJSON( "{'flags':[[true, false],[true]]}" ).as( ListBean.class );
+        assertEquals( List.of( List.of( true, false ), List.of( true ) ), bean.flags() );
+    }
+
+    @Test
+    public void testAccess_ListExtendedObject()
+    {
+        ListBean bean = createJSON( "{'ages':[1,2,3],"
+            + "'flags':[[true, false],[true]],"
+            + "'recursive': [{'names': ['x','y']}]"
+            + "}" ).as( ListBean.class );
+        assertEquals( 1, bean.recursive().size() );
+        assertEquals( List.of( "x", "y" ), bean.recursive().get( 0 ).names() );
+    }
+
+    interface SetBean extends JsonObject
+    {
+        Set<Integer> ages();
+
+        Set<Integer> ages( Set<Integer> v );
+
+        Set<Set<TextStyle>> styles();
+
+        Set<SetBean> recursive();
+    }
+
+    @Test
+    public void testAccess_SetNull()
+    {
+        assertNull( createJSON( "{}" ).as( SetBean.class ).ages() );
+        assertNull( createJSON( "{'ages':null}" ).as( SetBean.class ).ages() );
+        assertEquals( Set.of(), createJSON( "{}" ).as( SetBean.class ).ages( Set.of() ) );
+    }
+
+    @Test
+    public void testAccess_SetEmpty()
+    {
+        assertEquals( Set.of(), createJSON( "{'ages':[]}" ).as( SetBean.class ).ages() );
+    }
+
+    @Test
+    public void testAccess_SetInteger()
+    {
+        assertEquals( Set.of( 1, 2, 3 ), createJSON( "{'ages':[1,2,3,3]}" ).as( SetBean.class ).ages() );
+    }
+
+    @Test
+    public void testAccess_SetSetEnum()
+    {
+        SetBean obj = createJSON( "{'styles':[['FULL', 'SHORT'], ['NARROW']]}" ).as( SetBean.class );
+        assertEquals( Set.of( Set.of( TextStyle.FULL, TextStyle.SHORT ), Set.of( TextStyle.NARROW ) ), obj.styles() );
+    }
+
+    interface MapBean extends JsonObject
+    {
+        Map<String, TextStyle> styles();
+
+        Map<String, TextStyle> styles( Map<String, TextStyle> v );
+
+        Map<String, Map<String, String>> messages();
+
+        Map<String, Character> digits();
+
+        Map<TextStyle, List<String>> argsByType();
+
+        Map<Integer, MapBean> recursive();
+    }
+
+    @Test
+    public void testAccess_MapNull()
+    {
+        assertNull( createJSON( "{}" ).as( MapBean.class ).styles() );
+        assertNull( createJSON( "{'styles':null}" ).as( MapBean.class ).styles() );
+        assertEquals( Map.of(), createJSON( "{}" ).as( MapBean.class ).styles( Map.of() ) );
+    }
+
+    @Test
+    public void testAccess_MapEmpty()
+    {
+        assertEquals( Map.of(), createJSON( "{'styles':[]}" ).as( MapBean.class ).styles() );
+    }
+
+    @Test
+    public void testAccess_MapEnumValues()
+    {
+        MapBean bean = createJSON( "{'styles': {'a': 'FULL', 'b': 'SHORT'}}" ).as( MapBean.class );
+        assertEquals( Map.of( "a", TextStyle.FULL, "b", TextStyle.SHORT ), bean.styles() );
+    }
+
+    @Test
+    public void testAccess_MapMapStringValues()
+    {
+        MapBean bean = createJSON( "{'messages': {'a':{'hello':'world'}, 'b':{}}}" ).as( MapBean.class );
+        assertEquals( Map.of( "a", Map.of( "hello", "world" ), "b", Map.of() ), bean.messages() );
+    }
+
+    @Test
+    public void testAccess_MapCharacterValues()
+    {
+        MapBean obj = createJSON( "{'digits':{'A':'1', 'B':'2'}}" ).as( MapBean.class );
+        assertEquals( Map.of( "A", '1', "B", '2' ), obj.digits() );
+    }
+
+    @Test
+    public void testAccess_MapEnumKeys()
+    {
+        MapBean obj = createJSON( "{'argsByType': {'FULL': ['hey', 'ho'], 'SHORT': ['lets', 'go']}}" )
+            .as( MapBean.class );
+        assertEquals( Map.of( TextStyle.FULL, List.of( "hey", "ho" ), TextStyle.SHORT, List.of( "lets", "go" ) ),
+            obj.argsByType() );
+    }
+
+    @Test
+    public void testAccess_MapExtendedObjectValues()
+    {
+        MapBean obj = createJSON( "{'recursive':{'1':{}, '2':{'recursive':{'3':{'digits':{'a':'A'}}}}}}" )
+            .as( MapBean.class );
+        assertEquals( 2, obj.recursive().size() );
+        assertTrue( obj.recursive().get( 1 ).isEmpty() );
+        MapBean two = obj.recursive().get( 2 );
+        assertEquals( 1, two.size() );
+        assertEquals( Map.of( "a", 'A' ), two.recursive().get( 3 ).digits() );
+    }
+
+    interface StreamBean extends JsonObject
+    {
+
+        Stream<Integer> numbers();
+
+        Stream<List<String>> lists();
+    }
+
+    @Test
+    public void testAccess_StreamOfNumbers()
+    {
+        StreamBean obj = createJSON( "{'numbers':[1,2,3]}" ).as( StreamBean.class );
+        assertEquals( Stream.of( 1, 2, 3 ).collect( toList() ), obj.numbers().collect( toList() ) );
+    }
+
+    @Test
+    public void testAccess_StreamOfListOfStrings()
+    {
+        StreamBean obj = createJSON( "{'lists':[['a','b'],['1','2']]}" ).as( StreamBean.class );
+        assertEquals( List.of( List.of( "a", "b" ), List.of( "1", "2" ) ), obj.lists().collect( toList() ) );
+    }
+
+    interface OptionalBean extends JsonValue
+    {
+
+        Optional<String> maybeString();
+
+        Optional<List<String>> maybeList();
+    }
+
+    @Test
+    public void testAccess_OptionalEmpty()
+    {
+        assertEquals( Optional.empty(), createJSON( "{}" ).as( OptionalBean.class ).maybeString() );
+        assertEquals( Optional.empty(), createJSON( "{'maybeString':null}" ).as( OptionalBean.class ).maybeString() );
+    }
+
+    @Test
+    public void testAccess_OptionalString()
+    {
+        OptionalBean obj = createJSON( "{'maybeString':'hello'}" ).as( OptionalBean.class );
+        assertEquals( "hello", obj.maybeString().orElse( "not" ) );
+    }
+
+    @Test
+    public void testAccess_OptionalListString()
+    {
+        OptionalBean obj = createJSON( "{'maybeList':['hello']}" ).as( OptionalBean.class );
+        assertEquals( List.of( "hello" ), obj.maybeList().orElse( List.of() ) );
+    }
+
+    private static JsonResponse createJSON( String content )
+    {
+        return new JsonResponse( content.replace( '\'', '"' ) );
+    }
+}


### PR DESCRIPTION
### Summary
Adds a lazy version of "POJO mapping" to the library.

Sticking with the lazy "virtual" concept of the JSON tree the way JSON can be mapped to a Java representation is exploiting the already existing features of the virtual tree.

A JSON object graph can be mapped to its Java form by declaring a Java interface representation of it using common JDK types.

```java
interface POJO extends JsonValue {
  int getAge();
  List<String> getNames();
  boolean isEager();
}
```
A suitable JSON document would look like this:
```json
{
  "age": 42,
  "names": ["Ringo", "Star"],
  "eager": true
}
```
To "map" the JSON to Java one simply does:
```java
POJO obj = JsonValue.of("...").as( POJO.class );
```
So far this is again just a view, a way of looking at the the underlying tree.
First if a property is accessed it will be parsed and mapped individually. 
The `POJO` object is never really created as an independent object instance.
Instead every time a property is accessed the value found in the JSON document is attempted to map to the Java type expected by the methods return type.

### Type Support
This mapping on access is configured via the new `JsonTypedAccessStore`.
The default implementation `JsonTypedAccess` comes with a wide support JDK types common for modelling data.
This includes:

* primitives and their wrapper types
* `String`
* `enum`s
* `List`s, `Set`s, `Map`s
* `Stream`
* `Optional`
* `URL`, `UUID`, `Date` (and new date types)

Further type accessors can be added by the user if needed.
All types can be mixed without limitation. This includes mixing these types with the `JsonValue` tree types.

A new object type can either inherit from `JsonValue` or `JsonObject` depending on if the author wants their methods being inherited by the new POJO object.

### Names
The getters can use prefixes `get`/`is` or not. The member name is the getter name without potential prefix starting with a lower case letter.

### Undefined Values
The behaviour in case a value is not defined in the JSON document depends on the way it is accessed and is consistent with the behaviour of the `JsonValue` API (as it is used internally).

In essence this means
* accessing a undefined primitive value throws a `NoSuchElementException`
* accessing an undefined object type returns `null`
* accessing an undefined collection return `null`
* accessing an empty collection returns the empty collection
* accessing an undefined or empty stream returns the empty `Stream`
* accessing a undefined as `Optional` returns `Optional.empty()`, and `null` value from the access equally will also become `Optional.empty()`.

Any accessor method can get a default value parameter. This has to be of the same type as the return type of the method.
If a value is undefined in the JSON document and a default parameter is provided the default is returned.

### Automatic Testing
The mapping is tested fairly extensive in newly added test class.
