### PR TITLE
feat: types access with cache

### DIFF
--- a/src/main/java/org/hisp/dhis/jsontree/JsonAppender.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonAppender.java
@@ -146,7 +146,7 @@ public class JsonAppender implements JsonBuilder, JsonObjectBuilder, JsonArrayBu
     private JsonNode toNode()
     {
         String json = toStr.get();
-        return json == null ? null : new JsonDocument( json ).get( "$" );
+        return json == null ? null : JsonNode.of( json );
     }
 
     /*

--- a/src/main/java/org/hisp/dhis/jsontree/JsonDocument.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonDocument.java
@@ -316,7 +316,13 @@ public final class JsonDocument implements Serializable
         @Override
         public JsonNode get( String path )
         {
-            return JsonDocument.get( this.path.isEmpty() ? "$." + path : this.path + "." + path, nodesByPath );
+            if ( path.isEmpty() || "$".equals( path ) )
+            {
+                return this;
+            }
+            // trim any leading $. or . of the relative path
+            String absolutePath = this.path + "." + path.replaceFirst( "^\\$?\\.", "" );
+            return JsonDocument.get( absolutePath, nodesByPath );
         }
 
         @Override

--- a/src/main/java/org/hisp/dhis/jsontree/JsonDocument.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonDocument.java
@@ -255,7 +255,7 @@ public final class JsonDocument implements Serializable
             {
                 newJson.append( this.json, endIndex, this.json.length - endIndex );
             }
-            return new JsonDocument( newJson.toString() ).get( "$" );
+            return JsonNode.of( newJson.toString() );
         }
 
         @Override
@@ -266,9 +266,9 @@ public final class JsonDocument implements Serializable
                 throw new IllegalStateException( "`add` only allowed for objects but was: " + getType() );
             }
             int endIndex = endIndex() - 1;
-            return new JsonDocument(
+            return JsonNode.of(
                 String.valueOf( json, 0, endIndex ) + ", \"" + name + "\":" + value
-                    + String.valueOf( json, endIndex, json.length - endIndex ) ).get( "$" );
+                    + String.valueOf( json, endIndex, json.length - endIndex ) );
         }
 
         static JsonNode autoDetect( String path, char[] json, int atIndex, Map<String, JsonNode> nodesByPath )

--- a/src/main/java/org/hisp/dhis/jsontree/JsonList.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonList.java
@@ -192,11 +192,12 @@ public interface JsonList<E extends JsonValue> extends JsonCollection, Iterable<
     }
 
     /**
-     * @return this list as a {@link Stream}
+     * @return this list as a {@link Stream}, if this node does not exist or is
+     *         JSON {@code null} the stream is empty
      */
     default Stream<E> stream()
     {
-        return StreamSupport.stream( spliterator(), false );
+        return isUndefined() ? Stream.empty() : StreamSupport.stream( spliterator(), false );
     }
 
     /**
@@ -208,7 +209,8 @@ public interface JsonList<E extends JsonValue> extends JsonCollection, Iterable<
      * @param <T> type of result list elements
      * @return this list mapped to a {@link List} of elements mapped by the
      *         provided mapper function from the {@link JsonValue}s of this
-     *         {@link JsonList}.
+     *         {@link JsonList}. Undefined or JSON null is mapped to an empty
+     *         list.
      * @throws java.util.NoSuchElementException in case a source element
      *         {@link JsonValue} does not exist
      *
@@ -228,7 +230,8 @@ public interface JsonList<E extends JsonValue> extends JsonCollection, Iterable<
      *        {@link JsonValue#exists()}
      * @param <T> type of result list elements
      * @return mapped list using the default in case a {@link JsonValue} in this
-     *         list does not exist
+     *         list does not exist. Undefined or JSON null is mapped to an empty
+     *         list.
      */
     default <T> List<T> toList( Function<E, T> toValue, T whenNotExists )
     {
@@ -243,14 +246,18 @@ public interface JsonList<E extends JsonValue> extends JsonCollection, Iterable<
      * @param toValue maps from {@link JsonValue} to plain value
      * @param <T> type of result list elements
      * @return existing elements of this list mapped by the provided toValue
-     *         function
+     *         function. Undefined or JSON null is mapped to an empty list.
      */
     default <T> List<T> toListOfElementsThatExists( Function<E, T> toValue )
     {
+        if ( isUndefined() )
+        {
+            return List.of();
+        }
         ArrayList<T> list = new ArrayList<>( size() );
         for ( E e : this )
         {
-            if ( e.exists() )
+            if ( !e.isUndefined() )
             {
                 list.add( toValue.apply( e ) );
             }

--- a/src/main/java/org/hisp/dhis/jsontree/JsonMultiMap.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonMultiMap.java
@@ -82,6 +82,10 @@ public interface JsonMultiMap<E extends JsonValue> extends JsonMap<JsonList<E>>
      */
     default <T> Map<String, List<T>> toMap( Function<E, T> mapper, Comparator<T> order )
     {
+        if ( isUndefined() )
+        {
+            return Map.of();
+        }
         Map<String, List<T>> res = new LinkedHashMap<>();
         for ( String key : keys() )
         {

--- a/src/main/java/org/hisp/dhis/jsontree/JsonNode.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonNode.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.jsontree;
 
+import static java.lang.String.format;
+
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
@@ -54,6 +56,14 @@ import org.hisp.dhis.jsontree.JsonDocument.JsonNodeType;
  */
 public interface JsonNode extends Serializable
 {
+    /**
+     * Create a new lazily parsed {@link JsonNode} document.
+     *
+     * @param json a JSON value/document
+     * @return given document as {@link JsonNode} API
+     *
+     * @since 0.4
+     */
     static JsonNode of( String json )
     {
         return new JsonDocument( json ).get( "$" );
@@ -63,6 +73,12 @@ public interface JsonNode extends Serializable
      * @return the type of the node as derived from the node beginning
      */
     JsonNodeType getType();
+
+    default JsonNode get( String path )
+    {
+        throw new JsonDocument.JsonPathException(
+            format( "This is a leaf node of type %s that does not have any children at path: %s", getType(), path ) );
+    }
 
     /**
      * Size of an array of number of object members.

--- a/src/main/java/org/hisp/dhis/jsontree/JsonNode.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonNode.java
@@ -54,6 +54,11 @@ import org.hisp.dhis.jsontree.JsonDocument.JsonNodeType;
  */
 public interface JsonNode extends Serializable
 {
+    static JsonNode of( String json )
+    {
+        return new JsonDocument( json ).get( "$" );
+    }
+
     /**
      * @return the type of the node as derived from the node beginning
      */
@@ -262,7 +267,7 @@ public interface JsonNode extends Serializable
      */
     default JsonNode extract()
     {
-        return new JsonDocument( getDeclaration() ).get( "$" );
+        return of( getDeclaration() );
     }
 
     /**

--- a/src/main/java/org/hisp/dhis/jsontree/JsonNode.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonNode.java
@@ -76,6 +76,10 @@ public interface JsonNode extends Serializable
 
     default JsonNode get( String path )
     {
+        if ( path.isEmpty() || "$".equals( path ) )
+        {
+            return this;
+        }
         throw new JsonDocument.JsonPathException(
             format( "This is a leaf node of type %s that does not have any children at path: %s", getType(), path ) );
     }

--- a/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
@@ -252,7 +252,7 @@ public interface JsonObject extends JsonCollection
         Optional<JsonNode> match = node().find( JsonNodeType.OBJECT, node -> {
             try
             {
-                return test.test( new JsonResponse( node.getDeclaration() ).asObject( type ) );
+                return test.test( JsonValue.of( node.getDeclaration() ).asObject().asObject( type ) );
             }
             catch ( RuntimeException ex )
             {
@@ -260,8 +260,8 @@ public interface JsonObject extends JsonCollection
             }
         } );
         return !match.isPresent()
-            ? JsonResponse.NULL.as( type )
-            : new JsonResponse( match.get().getDeclaration() ).asObject( type );
+            ? JsonValue.NULL.as( type )
+            : JsonValue.of( match.get().getDeclaration() ).asObject().asObject( type );
     }
 
     /**

--- a/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
@@ -44,9 +44,9 @@ import org.hisp.dhis.jsontree.JsonDocument.JsonNodeType;
  * Represents a JSON object node.
  *
  * As all nodes are mere views or virtual field access will never throw a
- * {@link java.util.NoSuchElementException}. Whether or not a field with a given
- * name exists is determined first when {@link JsonValue#exists()} or other
- * value accessing operations are performed on a node.
+ * {@link java.util.NoSuchElementException}. Whether a field with a given name
+ * exists is determined first when {@link JsonValue#exists()} or other value
+ * accessing operations are performed on a node.
  *
  * @author Jan Bernitt
  */

--- a/src/main/java/org/hisp/dhis/jsontree/JsonResponse.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonResponse.java
@@ -79,9 +79,9 @@ import org.hisp.dhis.jsontree.JsonTypedAccessStore.JsonGenericTypedAccessor;
  */
 public final class JsonResponse implements JsonObject, JsonArray, JsonString, JsonNumber, JsonBoolean, Serializable
 {
-    public static final JsonResponse NULL = new JsonResponse( new JsonDocument( "null" ), "$", JsonTypedAccess.GLOBAL );
+    public static final JsonResponse NULL = new JsonResponse( JsonNode.of( "null" ), "$", JsonTypedAccess.GLOBAL );
 
-    private final JsonDocument content;
+    private final JsonNode content;
 
     private final String path;
 
@@ -94,19 +94,14 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
 
     public JsonResponse( String content, JsonTypedAccessStore store )
     {
-        this( new JsonDocument( content.isEmpty() ? "{}" : content ), "$", store );
+        this( JsonNode.of( content.isEmpty() ? "{}" : content ), "$", store );
     }
 
-    private JsonResponse( JsonDocument content, String path, JsonTypedAccessStore store )
+    private JsonResponse( JsonNode content, String path, JsonTypedAccessStore store )
     {
         this.content = content;
         this.path = path;
         this.store = store;
-    }
-
-    public JsonDocument getJsonDocument()
-    {
-        return this.content;
     }
 
     private <T> T value( JsonNodeType expected, Function<JsonNode, T> get, Function<JsonPathException, T> orElse )

--- a/src/main/java/org/hisp/dhis/jsontree/JsonResponse.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonResponse.java
@@ -38,14 +38,19 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import org.hisp.dhis.jsontree.JsonDocument.JsonFormatException;
 import org.hisp.dhis.jsontree.JsonDocument.JsonNodeType;
@@ -79,29 +84,41 @@ import org.hisp.dhis.jsontree.JsonTypedAccessStore.JsonGenericTypedAccessor;
  */
 public final class JsonResponse implements JsonObject, JsonArray, JsonString, JsonNumber, JsonBoolean, Serializable
 {
-    public static final JsonResponse NULL = new JsonResponse( JsonNode.of( "null" ), "$", JsonTypedAccess.GLOBAL );
+    public static final JsonResponse NULL = new JsonResponse( JsonNode.of( "null" ), "$", JsonTypedAccess.GLOBAL,
+        null );
 
     private final JsonNode content;
 
     private final String path;
 
-    private final JsonTypedAccessStore store;
+    private final transient JsonTypedAccessStore store;
 
-    public JsonResponse( String content )
-    {
-        this( content, JsonTypedAccess.GLOBAL );
-    }
+    private final transient ConcurrentMap<String, Object> accessCache;
 
     public JsonResponse( String content, JsonTypedAccessStore store )
     {
-        this( JsonNode.of( content.isEmpty() ? "{}" : content ), "$", store );
+        this( JsonNode.of( content.isEmpty() ? "{}" : content ), "$", store, null );
     }
 
-    private JsonResponse( JsonNode content, String path, JsonTypedAccessStore store )
+    private JsonResponse( JsonNode content, String path, JsonTypedAccessStore store,
+        ConcurrentMap<String, Object> accessCache )
     {
         this.content = content;
         this.path = path;
         this.store = store;
+        this.accessCache = accessCache;
+    }
+
+    @Override
+    public boolean isAccessCached()
+    {
+        return accessCache != null;
+    }
+
+    @Override
+    public JsonResponse withAccessCached()
+    {
+        return isAccessCached() ? this : new JsonResponse( content, path, store, new ConcurrentHashMap<>() );
     }
 
     private <T> T value( JsonNodeType expected, Function<JsonNode, T> get, Function<JsonPathException, T> orElse )
@@ -148,13 +165,13 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
     @Override
     public <T extends JsonValue> T get( int index, Class<T> as )
     {
-        return asType( as, new JsonResponse( content, path + "[" + index + "]", store ) );
+        return asType( as, new JsonResponse( content, path + "[" + index + "]", store, accessCache ) );
     }
 
     @Override
     public <T extends JsonValue> T get( String name, Class<T> as )
     {
-        return asType( as, new JsonResponse( content, path + "." + name, store ) );
+        return asType( as, new JsonResponse( content, path + "." + name, store, accessCache ) );
     }
 
     @Override
@@ -164,7 +181,7 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
     }
 
     @SuppressWarnings( "unchecked" )
-    private <T extends JsonValue> T asType( Class<T> as, JsonValue res )
+    private <T extends JsonValue> T asType( Class<T> as, JsonResponse res )
     {
         return isExtended( as ) ? createProxy( as, res ) : (T) res;
     }
@@ -332,7 +349,7 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
     }
 
     @SuppressWarnings( "unchecked" )
-    private <E extends JsonValue> E createProxy( Class<E> as, JsonValue inner )
+    private <E extends JsonValue> E createProxy( Class<E> as, JsonResponse inner )
     {
         return (E) Proxy.newProxyInstance(
             Thread.currentThread().getContextClassLoader(), new Class[] { as },
@@ -387,7 +404,7 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
      * the accessor extract the value by using solely the underlying
      * {@link JsonValue} API.
      */
-    private Object callAbstractMethod( JsonValue inner, Method method, Object[] args )
+    private Object callAbstractMethod( JsonResponse inner, Method method, Object[] args )
     {
         JsonObject obj = inner.asObject();
         Class<?> resType = method.getReturnType();
@@ -397,11 +414,22 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
         {
             return args[0];
         }
+        if ( accessCache != null && isCacheable( resType ) )
+        {
+            String keyId = inner.path + "." + name + ":" + toSignature( method.getGenericReturnType() );
+            return accessCache.computeIfAbsent( keyId, key -> access( method, obj, name ) );
+        }
+        return access( method, obj, name );
+    }
+
+    private Object access( Method method, JsonObject obj, String name )
+    {
         Type genericType = method.getGenericReturnType();
-        JsonGenericTypedAccessor<?> accessor = store.accessor( resType );
+        JsonTypedAccessStore accessStore = store == null ? JsonTypedAccess.GLOBAL : store;
+        JsonGenericTypedAccessor<?> accessor = accessStore.accessor( method.getReturnType() );
         if ( accessor != null )
         {
-            return accessor.access( obj, name, genericType, store );
+            return accessor.access( obj, name, genericType, accessStore );
         }
         throw new UnsupportedOperationException( "No accessor registered for type: " + genericType );
     }
@@ -422,6 +450,22 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
         {
             throw ex.getTargetException();
         }
+    }
+
+    /**
+     * This is twofold: Concepts like {@link Stream} and {@link Iterator} should
+     * not be cached to work correctly.
+     *
+     * For all other types this is about reaching a balance between memory usage
+     * and CPU usage. Simple objects are recomputed whereas complex objects are
+     * not.
+     */
+    private boolean isCacheable( Class<?> resType )
+    {
+        return resType.isInterface()
+            && !Stream.class.isAssignableFrom( resType )
+            && !Iterator.class.isAssignableFrom( resType )
+            && !JsonPrimitive.class.isAssignableFrom( resType );
     }
 
     private static boolean isExtended( Class<?> declaringClass )
@@ -448,5 +492,44 @@ public final class JsonResponse implements JsonObject, JsonArray, JsonString, Js
             return toLowerCase( name.charAt( 3 ) ) + name.substring( 4 );
         }
         return name;
+    }
+
+    private String toSignature( Type type )
+    {
+        if ( type instanceof Class<?> )
+        {
+            return ((Class<?>) type).getCanonicalName();
+        }
+        if ( type instanceof ParameterizedType )
+        {
+            StringBuilder str = new StringBuilder();
+            toSignature( type, str );
+            return str.toString();
+        }
+        return "?";
+    }
+
+    private void toSignature( Type type, StringBuilder str )
+    {
+        if ( type instanceof Class<?> )
+        {
+            str.append( ((Class<?>) type).getCanonicalName() );
+            return;
+        }
+        if ( type instanceof ParameterizedType )
+        {
+            ParameterizedType pt = (ParameterizedType) type;
+            toSignature( pt.getRawType(), str );
+            str.append( '<' );
+            for ( Type ata : pt.getActualTypeArguments() )
+            {
+                str.append( toSignature( ata ) );
+            }
+            str.append( '>' );
+        }
+        else
+        {
+            str.append( '?' );
+        }
     }
 }

--- a/src/main/java/org/hisp/dhis/jsontree/JsonTypedAccess.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonTypedAccess.java
@@ -76,12 +76,16 @@ public final class JsonTypedAccess implements JsonTypedAccessStore
     public <T> JsonGenericTypedAccessor<T> accessor( Class<T> type )
     {
         JsonGenericTypedAccessor<T> res = (JsonGenericTypedAccessor<T>) byResultType.get( type );
+        if ( res != null )
+        {
+            return res;
+        }
         if ( type.isEnum() )
         {
             // automatically provide enum mapping
             return (JsonGenericTypedAccessor<T>) byResultType.get( Enum.class );
         }
-        if ( res == null && JsonValue.class.isAssignableFrom( type ) )
+        if ( JsonValue.class.isAssignableFrom( type ) )
         {
             // automatically provide JsonValue subtype mapping
             return (JsonGenericTypedAccessor<T>) byResultType.get( JsonValue.class );

--- a/src/main/java/org/hisp/dhis/jsontree/JsonValue.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonValue.java
@@ -65,6 +65,11 @@ package org.hisp.dhis.jsontree;
 public interface JsonValue
 {
     /**
+     * Constant for JSON {@code null} value.
+     */
+    JsonValue NULL = JsonResponse.NULL;
+
+    /**
      * Lift an actual {@link JsonNode} tree to a virtual {@link JsonValue}.
      *
      * @param node non null
@@ -72,7 +77,7 @@ public interface JsonValue
      */
     static JsonValue of( JsonNode node )
     {
-        return node == null ? JsonResponse.NULL : of( node.getDeclaration() );
+        return node == null ? NULL : of( node.getDeclaration() );
     }
 
     /**
@@ -86,9 +91,20 @@ public interface JsonValue
         return of( json, JsonTypedAccess.GLOBAL );
     }
 
+    /**
+     * View the provided JSON string as virtual lazy evaluated tree using the
+     * provided {@link JsonTypedAccessStore} for mapping to Java method return
+     * types.
+     *
+     * @param json a JSON string
+     * @param store mapping used to map JSON values to the Java method return
+     *        types of abstract methods, when {@code null} default mapping is
+     *        used
+     * @return virtual JSON tree root {@link JsonValue}
+     */
     static JsonValue of( String json, JsonTypedAccessStore store )
     {
-        return json == null || "null".equals( json ) ? JsonResponse.NULL : new JsonResponse( json, store );
+        return json == null || "null".equals( json ) ? NULL : new JsonResponse( json, store );
     }
 
     /**
@@ -206,4 +222,24 @@ public interface JsonValue
      *         exist in the JSON document
      */
     JsonNode node();
+
+    /**
+     * @return true, if results of JSON to Java method return types mapping via
+     *         {@link JsonTypedAccessStore} are cached so that complex return
+     *         values are only computed once. Any interface return type is
+     *         considered a complex type.
+     */
+    default boolean isAccessCached()
+    {
+        return false;
+    }
+
+    /**
+     * @return This value but with typed access cached if supported. Check using
+     *         {@link #isAccessCached()} on result.
+     */
+    default JsonValue withAccessCached()
+    {
+        return this;
+    }
 }

--- a/src/main/java/org/hisp/dhis/jsontree/JsonValue.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonValue.java
@@ -83,7 +83,12 @@ public interface JsonValue
      */
     static JsonValue of( String json )
     {
-        return json == null || "null".equals( json ) ? JsonResponse.NULL : new JsonResponse( json );
+        return of( json, JsonTypedAccess.GLOBAL );
+    }
+
+    static JsonValue of( String json, JsonTypedAccessStore store )
+    {
+        return json == null || "null".equals( json ) ? JsonResponse.NULL : new JsonResponse( json, store );
     }
 
     /**

--- a/src/test/java/org/hisp/dhis/jsontree/JsonAppenderTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonAppenderTest.java
@@ -285,14 +285,14 @@ public class JsonAppenderTest
     public void testObject_JsonNode()
     {
         assertJson( "{'node':['a','b']}", builder.toObject( obj -> obj
-            .addMember( "node", new JsonDocument( "[\"a\",\"b\"]" ).get( "$" ) ) ) );
+            .addMember( "node", JsonNode.of( "[\"a\",\"b\"]" ) ) ) );
     }
 
     @Test
     public void testArray_JsonNode()
     {
         assertJson( "[['a','b']]", builder.toArray( arr -> arr
-            .addElement( new JsonDocument( "[\"a\",\"b\"]" ).get( "$" ) ) ) );
+            .addElement( JsonNode.of( "[\"a\",\"b\"]" ) ) ) );
     }
 
     private static void assertJson( String expected, JsonNode actual )

--- a/src/test/java/org/hisp/dhis/jsontree/JsonDocumentTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonDocumentTest.java
@@ -59,7 +59,7 @@ public class JsonDocumentTest
     @Test
     public void testStringNode()
     {
-        JsonNode node = new JsonDocument( "\"hello\"" ).get( "$" );
+        JsonNode node = JsonNode.of( "\"hello\"" );
         assertEquals( JsonNodeType.STRING, node.getType() );
         assertEquals( "hello", node.value() );
         assertEquals( 0, node.startIndex() );
@@ -80,14 +80,14 @@ public class JsonDocumentTest
     @Test
     public void testStringNode_EscapedChars()
     {
-        JsonNode node = new JsonDocument( "\"\\\\\\/\\t\\r\\n\\f\\b\\\"\"" ).get( "$" );
+        JsonNode node = JsonNode.of( "\"\\\\\\/\\t\\r\\n\\f\\b\\\"\"" );
         assertEquals( "\\/\t\r\n\f\b\"", node.value() );
     }
 
     @Test
     public void testStringNode_Unsupported()
     {
-        JsonNode node = new JsonDocument( "\"hello\"" ).get( "$" );
+        JsonNode node = JsonNode.of( "\"hello\"" );
         Exception ex = assertThrows( UnsupportedOperationException.class, node::isEmpty );
         assertEquals( "STRING node has no empty property.", ex.getMessage() );
         ex = assertThrows( UnsupportedOperationException.class, node::size );
@@ -101,7 +101,7 @@ public class JsonDocumentTest
     @Test
     public void testStringNode_EOI()
     {
-        JsonNode node = new JsonDocument( "\"hello" ).get( "$" );
+        JsonNode node = JsonNode.of( "\"hello" );
         JsonFormatException ex = assertThrows( JsonFormatException.class, node::value );
         assertEquals( "Expected \" but reach EOI: \"hello", ex.getMessage() );
     }
@@ -109,7 +109,7 @@ public class JsonDocumentTest
     @Test
     public void testNumberNode_Integer()
     {
-        JsonNode node = new JsonDocument( "123" ).get( "$" );
+        JsonNode node = JsonNode.of( "123" );
         assertEquals( JsonNodeType.NUMBER, node.getType() );
         assertEquals( 123, node.value() );
     }
@@ -117,7 +117,7 @@ public class JsonDocumentTest
     @Test
     public void testNumberNode_Unsupported()
     {
-        JsonNode node = new JsonDocument( "1e-2" ).get( "$" );
+        JsonNode node = JsonNode.of( "1e-2" );
         Exception ex = assertThrows( UnsupportedOperationException.class, node::isEmpty );
         assertEquals( "NUMBER node has no empty property.", ex.getMessage() );
         ex = assertThrows( UnsupportedOperationException.class, node::size );
@@ -131,7 +131,7 @@ public class JsonDocumentTest
     @Test
     public void testNumberNode_EOI()
     {
-        JsonNode node = new JsonDocument( "-" ).get( "$" );
+        JsonNode node = JsonNode.of( "-" );
         JsonFormatException ex = assertThrows( JsonFormatException.class, node::value );
         assertEquals( "Expected character but reached EOI: -", ex.getMessage() );
     }
@@ -139,7 +139,7 @@ public class JsonDocumentTest
     @Test
     public void testNumberNode_Long()
     {
-        JsonNode node = new JsonDocument( "2147483648" ).get( "$" );
+        JsonNode node = JsonNode.of( "2147483648" );
         assertEquals( JsonNodeType.NUMBER, node.getType() );
         assertEquals( 2147483648L, node.value() );
     }
@@ -147,7 +147,7 @@ public class JsonDocumentTest
     @Test
     public void testBooleanNode_True()
     {
-        JsonNode node = new JsonDocument( "true" ).get( "$" );
+        JsonNode node = JsonNode.of( "true" );
         assertEquals( JsonNodeType.BOOLEAN, node.getType() );
         assertEquals( true, node.value() );
     }
@@ -155,7 +155,7 @@ public class JsonDocumentTest
     @Test
     public void testBooleanNode_Unsupported()
     {
-        JsonNode node = new JsonDocument( "false" ).get( "$" );
+        JsonNode node = JsonNode.of( "false" );
         Exception ex = assertThrows( UnsupportedOperationException.class, node::isEmpty );
         assertEquals( "BOOLEAN node has no empty property.", ex.getMessage() );
         ex = assertThrows( UnsupportedOperationException.class, node::size );
@@ -169,7 +169,7 @@ public class JsonDocumentTest
     @Test
     public void testBooleanNode_False()
     {
-        JsonNode node = new JsonDocument( "false" ).get( "$" );
+        JsonNode node = JsonNode.of( "false" );
         assertEquals( JsonNodeType.BOOLEAN, node.getType() );
         assertEquals( false, node.value() );
     }
@@ -177,7 +177,7 @@ public class JsonDocumentTest
     @Test
     public void testNullNode()
     {
-        JsonNode node = new JsonDocument( "null" ).get( "$" );
+        JsonNode node = JsonNode.of( "null" );
         assertEquals( JsonNodeType.NULL, node.getType() );
         assertNull( node.value() );
     }
@@ -185,7 +185,7 @@ public class JsonDocumentTest
     @Test
     public void testNullNode_Unsupported()
     {
-        JsonNode node = new JsonDocument( "null" ).get( "$" );
+        JsonNode node = JsonNode.of( "null" );
         Exception ex = assertThrows( UnsupportedOperationException.class, node::isEmpty );
         assertEquals( "NULL node has no empty property.", ex.getMessage() );
         ex = assertThrows( UnsupportedOperationException.class, node::size );
@@ -206,7 +206,7 @@ public class JsonDocumentTest
     @Test
     public void testArray_Numbers()
     {
-        JsonNode node = new JsonDocument( "[1, 2 ,3]" ).get( "$" );
+        JsonNode node = JsonNode.of( "[1, 2 ,3]" );
         assertEquals( JsonNodeType.ARRAY, node.getType() );
         assertFalse( node.isEmpty() );
         assertEquals( 3, node.size() );
@@ -215,7 +215,7 @@ public class JsonDocumentTest
     @Test
     public void testArray_Unsupported()
     {
-        JsonNode node = new JsonDocument( "[]" ).get( "$" );
+        JsonNode node = JsonNode.of( "[]" );
         Exception ex = assertThrows( UnsupportedOperationException.class, node::members );
         assertEquals( "ARRAY node has no members property.", ex.getMessage() );
     }
@@ -253,7 +253,7 @@ public class JsonDocumentTest
     @Test
     public void testObject_Flat()
     {
-        JsonNode root = new JsonDocument( "{\"a\":1, \"bb\":true , \"ccc\":null }" ).get( "$" );
+        JsonNode root = JsonNode.of( "{\"a\":1, \"bb\":true , \"ccc\":null }" );
         assertEquals( JsonNodeType.OBJECT, root.getType() );
         assertFalse( root.isEmpty() );
         assertEquals( 3, root.size() );
@@ -352,7 +352,7 @@ public class JsonDocumentTest
     @Test
     public void testObject_Unsupported()
     {
-        JsonNode node = new JsonDocument( "{}" ).get( "$" );
+        JsonNode node = JsonNode.of( "{}" );
         Exception ex = assertThrows( UnsupportedOperationException.class, node::elements );
         assertEquals( "OBJECT node has no elements property.", ex.getMessage() );
     }
@@ -412,7 +412,7 @@ public class JsonDocumentTest
     @Test
     public void testNull()
     {
-        JsonNode node = new JsonDocument( "null" ).get( "$" );
+        JsonNode node = JsonNode.of( "null" );
         assertEquals( JsonNodeType.NULL, node.getType() );
         assertNull( node.value() );
     }

--- a/src/test/java/org/hisp/dhis/jsontree/JsonDocumentTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonDocumentTest.java
@@ -69,10 +69,10 @@ public class JsonDocumentTest
     public void testStringNode_Unicode()
     {
         // use an array to see that unicode skipping works as well
-        JsonNode node0 = new JsonDocument( "[\"Star \\uD83D\\uDE80 ship\", 12]" ).get( "$[0]" );
+        JsonNode node0 = JsonNode.of( "[\"Star \\uD83D\\uDE80 ship\", 12]" ).get( "[0]" );
         assertEquals( JsonNodeType.STRING, node0.getType() );
         assertEquals( "Star \uD83D\uDE80 ship", node0.value() );
-        JsonNode node1 = new JsonDocument( "[\"Star \\uD83D\\uDE80 ship\", 12]" ).get( "$[1]" );
+        JsonNode node1 = JsonNode.of( "[\"Star \\uD83D\\uDE80 ship\", 12]" ).get( "[1]" );
         assertEquals( JsonNodeType.NUMBER, node1.getType() );
         assertEquals( 12, node1.value() );
     }
@@ -199,8 +199,8 @@ public class JsonDocumentTest
     @Test
     public void testArray_IndexOutOfBounds()
     {
-        JsonDocument doc = new JsonDocument( "[]" );
-        assertThrows( JsonPathException.class, () -> doc.get( "$[0]" ) );
+        JsonNode doc = JsonNode.of( "[]" );
+        assertThrows( JsonPathException.class, () -> doc.get( "[0]" ) );
     }
 
     @Test
@@ -223,9 +223,7 @@ public class JsonDocumentTest
     @Test
     public void testArray_IterateElements()
     {
-        JsonDocument doc = new JsonDocument( "[ 1,2 , true , false, \"hello\",{},[]]" );
-
-        JsonNode root = doc.get( "$" );
+        JsonNode root = JsonNode.of( "[ 1,2 , true , false, \"hello\",{},[]]" );
 
         Iterator<JsonNode> elements = root.elements( false );
         JsonNode e0 = elements.next();
@@ -264,7 +262,7 @@ public class JsonDocumentTest
     @Test
     public void testObject_Deep()
     {
-        JsonDocument doc = new JsonDocument( "{\"a\": { \"b\" : [12, false] } }" );
+        JsonNode doc = JsonNode.of( "{\"a\": { \"b\" : [12, false] } }" );
 
         JsonNode root = doc.get( "$" );
         assertEquals( JsonNodeType.OBJECT, root.getType() );
@@ -301,7 +299,7 @@ public class JsonDocumentTest
     @Test
     public void testObject_DeepAccess()
     {
-        JsonDocument doc = new JsonDocument( "{\"a\": { \"b\" : [12, false] } }" );
+        JsonNode doc = JsonNode.of( "{\"a\": { \"b\" : [12, false] } }" );
 
         JsonNode root = doc.get( "$" );
         assertEquals( JsonNodeType.OBJECT, root.getType() );
@@ -324,7 +322,7 @@ public class JsonDocumentTest
     @Test
     public void testObject_IterateMembers()
     {
-        JsonDocument doc = new JsonDocument( "{\"a\": 1,\"b\":2 ,\"c\": true ,\"d\":false}" );
+        JsonNode doc = JsonNode.of( "{\"a\": 1,\"b\":2 ,\"c\": true ,\"d\":false}" );
 
         JsonNode root = doc.get( "$" );
 
@@ -360,7 +358,7 @@ public class JsonDocumentTest
     @Test
     public void testObject_NoSuchProperty()
     {
-        JsonDocument doc = new JsonDocument( "{\"a\": { \"b\" : [12, false] } }" );
+        JsonNode doc = JsonNode.of( "{\"a\": { \"b\" : [12, false] } }" );
 
         JsonPathException ex = assertThrows( JsonPathException.class, () -> doc.get( ".a.notFound" ) );
         assertEquals( "Path `.a.notFound` does not exist, object `.a` does not have a property `notFound`",
@@ -370,7 +368,7 @@ public class JsonDocumentTest
     @Test
     public void testObject_NoSuchIndex()
     {
-        JsonDocument doc = new JsonDocument( "{\"a\": { \"b\" : [12, false] } }" );
+        JsonNode doc = JsonNode.of( "{\"a\": { \"b\" : [12, false] } }" );
 
         JsonPathException ex = assertThrows( JsonPathException.class, () -> doc.get( ".a.b[3]" ) );
         assertEquals( "Path `.a.b[3]` does not exist, array `.a.b` has only `2` elements.",
@@ -380,7 +378,7 @@ public class JsonDocumentTest
     @Test
     public void testObject_WrongNodeTypeArray()
     {
-        JsonDocument doc = new JsonDocument( "{\"a\": { \"b\" : 42 } }" );
+        JsonNode doc = JsonNode.of( "{\"a\": { \"b\" : 42 } }" );
 
         JsonPathException ex = assertThrows( JsonPathException.class, () -> doc.get( ".a.b[1]" ) );
         assertEquals( "Path `.a.b[1]` does not exist, parent `.a.b` is not an ARRAY but a NUMBER node.",
@@ -390,7 +388,7 @@ public class JsonDocumentTest
     @Test
     public void testObject_WrongNodeTypeObject()
     {
-        JsonDocument doc = new JsonDocument( "{\"a\": 42 }" );
+        JsonNode doc = JsonNode.of( "{\"a\": 42 }" );
 
         JsonPathException ex = assertThrows( JsonPathException.class, () -> doc.get( ".a.b.[1]" ) );
         assertEquals( "Path `.a.b.[1]` does not exist, parent `.a` is not an OBJECT but a NUMBER node.",
@@ -400,7 +398,7 @@ public class JsonDocumentTest
     @Test
     public void testString_MissingQuotes()
     {
-        JsonDocument doc = new JsonDocument( "{\"a\": hello }" );
+        JsonNode doc = JsonNode.of( "{\"a\": hello }" );
 
         JsonFormatException ex = assertThrows( JsonFormatException.class, () -> doc.get( ".a" ) );
         assertEquals(
@@ -420,7 +418,7 @@ public class JsonDocumentTest
     @Test
     public void testExtractAndReplace()
     {
-        JsonDocument doc = new JsonDocument( "{\"a\": { \"b\" : [12, false] } }" );
+        JsonNode doc = JsonNode.of( "{\"a\": { \"b\" : [12, false] } }" );
         JsonNode onlyA = doc.get( "$.a" ).extract();
         assertEquals( "{ \"b\" : [12, false] }", onlyA.toString() );
         assertEquals( "{ \"b\" : [42, false] }",
@@ -430,7 +428,7 @@ public class JsonDocumentTest
     @Test
     public void testAdd()
     {
-        JsonDocument doc = new JsonDocument( "{\"a\": { \"b\" : [12, false] } }" );
+        JsonNode doc = JsonNode.of( "{\"a\": { \"b\" : [12, false] } }" );
         assertEquals( "{\"a\": { \"b\" : [12, false] , \"c\":{}} }",
             doc.get( ".a" ).addMember( "c", "{}" ).toString() );
     }
@@ -438,7 +436,7 @@ public class JsonDocumentTest
     @Test
     public void testVisit()
     {
-        JsonDocument doc = new JsonDocument( "{\"a\": { \"b\" : [12, false, \"hello\"] } }" );
+        JsonNode doc = JsonNode.of( "{\"a\": { \"b\" : [12, false, \"hello\"] } }" );
         JsonNode root = doc.get( "$" );
         assertEquals( 2, root.count( JsonNodeType.OBJECT ) );
         assertEquals( 1, root.count( JsonNodeType.NUMBER ) );

--- a/src/test/java/org/hisp/dhis/jsontree/JsonExpectedTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonExpectedTest.java
@@ -221,6 +221,6 @@ public class JsonExpectedTest
 
     private static JsonResponse createJSON( String content )
     {
-        return new JsonResponse( content.replace( '\'', '"' ) );
+        return new JsonResponse( content.replace( '\'', '"' ), JsonTypedAccess.GLOBAL );
     }
 }

--- a/src/test/java/org/hisp/dhis/jsontree/JsonListTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonListTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.jsontree;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Tests the additional utility methods of the {@link JsonList} interface.
+ *
+ * @author Jan Bernitt
+ */
+public class JsonListTest
+{
+    @Test
+    public void testList_stream_Undefined()
+    {
+        JsonList<JsonNumber> list = createJSON( "{}" ).getList( "missing", JsonNumber.class );
+        assertEquals( List.of(), list.stream().map( JsonNumber::intValue ).collect( toList() ) );
+    }
+
+    @Test
+    public void testList_stream_Null()
+    {
+        JsonList<JsonNumber> list = createJSON( "null" ).asList( JsonNumber.class );
+        assertEquals( List.of(), list.stream().map( JsonNumber::intValue ).collect( toList() ) );
+    }
+
+    @Test
+    public void testList_stream_Empty()
+    {
+        JsonList<JsonNumber> list = createJSON( "[]" ).asList( JsonNumber.class );
+        assertEquals( List.of(), list.stream().map( JsonNumber::intValue ).collect( toList() ) );
+    }
+
+    @Test
+    public void testList_toList_Undefined()
+    {
+        JsonList<JsonNumber> list = createJSON( "{}" ).getList( "missing", JsonNumber.class );
+        assertEquals( List.of(), list.toList( JsonNumber::intValue ) );
+    }
+
+    @Test
+    public void testList_toList_Null()
+    {
+        JsonList<JsonNumber> list = createJSON( "null" ).asList( JsonNumber.class );
+        assertEquals( List.of(), list.toList( JsonNumber::intValue ) );
+    }
+
+    @Test
+    public void testList_toList_Empty()
+    {
+        JsonList<JsonNumber> list = createJSON( "[]" ).asList( JsonNumber.class );
+        assertEquals( List.of(), list.toList( JsonNumber::intValue ) );
+    }
+
+    @Test
+    public void testList_toListOfElementsThatExists_Undefined()
+    {
+        JsonList<JsonNumber> list = createJSON( "{}" ).getList( "missing", JsonNumber.class );
+        assertEquals( List.of(), list.toListOfElementsThatExists( JsonNumber::intValue ) );
+    }
+
+    @Test
+    public void testList_toListOfElementsThatExists_Null()
+    {
+        JsonList<JsonNumber> list = createJSON( "null" ).asList( JsonNumber.class );
+        assertEquals( List.of(), list.toListOfElementsThatExists( JsonNumber::intValue ) );
+    }
+
+    @Test
+    public void testList_toListOfElementsThatExists_Empty()
+    {
+        JsonList<JsonNumber> list = createJSON( "[]" ).asList( JsonNumber.class );
+        assertEquals( List.of(), list.toListOfElementsThatExists( JsonNumber::intValue ) );
+    }
+
+    @Test
+    public void testList_toListOfElementsThatExists_OnlyNulls()
+    {
+        JsonList<JsonNumber> list = createJSON( "[null,null]" ).asList( JsonNumber.class );
+        assertEquals( List.of(), list.toListOfElementsThatExists( JsonNumber::intValue ) );
+    }
+
+    @Test
+    public void testList_toListOfElementsThatExists_Mixed()
+    {
+        JsonList<JsonNumber> list = createJSON( "[null,1,2,null,3]" ).asList( JsonNumber.class );
+        assertEquals( List.of( 1, 2, 3 ), list.toListOfElementsThatExists( JsonNumber::intValue ) );
+    }
+
+    private static JsonResponse createJSON( String content )
+    {
+        return new JsonResponse( content.replace( '\'', '"' ), JsonTypedAccess.GLOBAL );
+    }
+}

--- a/src/test/java/org/hisp/dhis/jsontree/JsonNodeTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonNodeTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.jsontree;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.hisp.dhis.jsontree.JsonDocument.JsonPathException;
+import org.junit.Test;
+
+/**
+ * Tests {@link JsonNode} specific aspects of the {@link JsonDocument}
+ * implementation of the interface.
+ *
+ * @author Jan Bernitt
+ */
+public class JsonNodeTest
+{
+    @Test
+    public void testGet_String()
+    {
+        assertGetThrowsJsonPathException( "\"hello\"",
+            "This is a leaf node of type STRING that does not have any children at path: foo" );
+    }
+
+    @Test
+    public void testGet_Number()
+    {
+        assertGetThrowsJsonPathException( "42",
+            "This is a leaf node of type NUMBER that does not have any children at path: foo" );
+    }
+
+    @Test
+    public void testGet_Boolean()
+    {
+        assertGetThrowsJsonPathException( "true",
+            "This is a leaf node of type BOOLEAN that does not have any children at path: foo" );
+    }
+
+    @Test
+    public void testGet_Null()
+    {
+        assertGetThrowsJsonPathException( "null",
+            "This is a leaf node of type NULL that does not have any children at path: foo" );
+    }
+
+    @Test
+    public void testGet_Object()
+    {
+        JsonNode root = JsonNode.of( "{\"a\":{\"b\":{\"c\":42}}}" );
+        assertEquals( 42, root.get( "a.b.c" ).value() );
+        JsonNode b = root.get( "a.b" );
+        assertEquals( 42, b.get( "c" ).value() );
+    }
+
+    @Test
+    public void testGet_Object_NoValueAtPath()
+    {
+        assertGetThrowsJsonPathException( "{\"a\":{\"b\":{\"c\":42}}}", "b",
+            "Path `.b` does not exist, object `` does not have a property `b`" );
+        assertGetThrowsJsonPathException( "{\"a\":{\"b\":{\"c\":42}}}", "a.c",
+            "Path `.a.c` does not exist, object `.a` does not have a property `c`" );
+    }
+
+    @Test
+    public void testGet_Array()
+    {
+        JsonNode root = JsonNode.of( "[[1,2],[3,4],{\"a\":5}]" );
+        assertEquals( 1, root.get( "[0][0]" ).value() );
+        JsonNode arr1 = root.get( "[1]" );
+        assertEquals( 4, arr1.get( "[1]" ).value() );
+        assertEquals( 5, root.get( "[2].a" ).value() );
+        assertEquals( 5, root.get( "[2]" ).get( "a" ).value() );
+    }
+
+    @Test
+    public void testGet_Array_NoValueAtPath()
+    {
+        assertGetThrowsJsonPathException( "[1,2]", "a", "Malformed path a at a." );
+        assertGetThrowsJsonPathException( "[[1,2],[]]", "[1][0]",
+            "Path `[1][0]` does not exist, array `[1]` has only `0` elements." );
+        assertGetThrowsJsonPathException( "[[1,2],[]]", "[0].a",
+            "Path `[0].a` does not exist, parent `[0]` is not an OBJECT but a ARRAY node." );
+    }
+
+    private static void assertGetThrowsJsonPathException( String json, String expected )
+    {
+        assertGetThrowsJsonPathException( json, "foo", expected );
+    }
+
+    private static void assertGetThrowsJsonPathException( String json, String path, String expected )
+    {
+        JsonNode root = JsonNode.of( json );
+        JsonPathException ex = assertThrows( JsonPathException.class, () -> root.get( path ) );
+        assertEquals( expected, ex.getMessage() );
+    }
+}

--- a/src/test/java/org/hisp/dhis/jsontree/JsonResponseTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonResponseTest.java
@@ -327,6 +327,6 @@ public class JsonResponseTest
 
     private static JsonResponse createJSON( String content )
     {
-        return new JsonResponse( content.replace( '\'', '"' ) );
+        return new JsonResponse( content.replace( '\'', '"' ), JsonTypedAccess.GLOBAL );
     }
 }

--- a/src/test/java/org/hisp/dhis/jsontree/JsonTypedAccessTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonTypedAccessTest.java
@@ -29,7 +29,10 @@ package org.hisp.dhis.jsontree;
 
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -37,7 +40,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.TextStyle;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -304,31 +309,31 @@ public class JsonTypedAccessTest
     @Test
     public void testAccess_DateNode()
     {
-        DateBean bean = createJSON( "{'aNode':'2000-01-01T00:00'}" ).as( DateBean.class );
-        assertEquals( LocalDate.of( 2000, 1, 1 ).atStartOfDay(), bean.aNode().date() );
+        DateBean obj = createJSON( "{'aNode':'2000-01-01T00:00'}" ).as( DateBean.class );
+        assertEquals( LocalDate.of( 2000, 1, 1 ).atStartOfDay(), obj.aNode().date() );
     }
 
     @Test
     public void testAccess_DateLocalDateTime()
     {
-        DateBean bean = createJSON( "{'aLocalDateTime':'2000-01-01T00:00'}" ).as( DateBean.class );
-        assertEquals( LocalDate.of( 2000, 1, 1 ).atStartOfDay(), bean.aLocalDateTime() );
+        DateBean obj = createJSON( "{'aLocalDateTime':'2000-01-01T00:00'}" ).as( DateBean.class );
+        assertEquals( LocalDate.of( 2000, 1, 1 ).atStartOfDay(), obj.aLocalDateTime() );
     }
 
     @Test
     public void testAccess_Date()
     {
-        DateBean bean = createJSON( "{'aDate':'2000-01-01T00:00'}" ).as( DateBean.class );
+        DateBean obj = createJSON( "{'aDate':'2000-01-01T00:00'}" ).as( DateBean.class );
         Date expected = Date.from( LocalDate.of( 2000, 1, 1 ).atStartOfDay().toInstant( ZoneOffset.UTC ) );
-        assertEquals( expected, bean.aDate() );
+        assertEquals( expected, obj.aDate() );
     }
 
     @Test
     public void testAccess_DateTimestamp()
     {
-        DateBean bean = createJSON( "{'aDate':946684800000}" ).as( DateBean.class );
+        DateBean obj = createJSON( "{'aDate':946684800000}" ).as( DateBean.class );
         Date expected = Date.from( LocalDate.of( 2000, 1, 1 ).atStartOfDay().toInstant( ZoneOffset.UTC ) );
-        assertEquals( expected, bean.aDate() );
+        assertEquals( expected, obj.aDate() );
     }
 
     interface ListBean extends JsonObject
@@ -342,6 +347,8 @@ public class JsonTypedAccessTest
         List<List<Boolean>> flags();
 
         List<ListBean> recursive();
+
+        Iterable<Integer> numbers();
     }
 
     @Test
@@ -373,19 +380,26 @@ public class JsonTypedAccessTest
     @Test
     public void testAccess_ListListBoolean()
     {
-        ListBean bean = createJSON( "{'flags':[[true, false],[true]]}" ).as( ListBean.class );
-        assertEquals( List.of( List.of( true, false ), List.of( true ) ), bean.flags() );
+        ListBean obj = createJSON( "{'flags':[[true, false],[true]]}" ).as( ListBean.class );
+        assertEquals( List.of( List.of( true, false ), List.of( true ) ), obj.flags() );
     }
 
     @Test
     public void testAccess_ListExtendedObject()
     {
-        ListBean bean = createJSON( "{'ages':[1,2,3],"
+        ListBean obj = createJSON( "{'ages':[1,2,3],"
             + "'flags':[[true, false],[true]],"
             + "'recursive': [{'names': ['x','y']}]"
             + "}" ).as( ListBean.class );
-        assertEquals( 1, bean.recursive().size() );
-        assertEquals( List.of( "x", "y" ), bean.recursive().get( 0 ).names() );
+        assertEquals( 1, obj.recursive().size() );
+        assertEquals( List.of( "x", "y" ), obj.recursive().get( 0 ).names() );
+    }
+
+    @Test
+    public void testAccess_IteratorIsList()
+    {
+        ListBean obj = createJSON( "{'numbers':[1,2,3]}" ).as( ListBean.class );
+        assertEquals( List.of( 1, 2, 3 ), obj.numbers() );
     }
 
     interface SetBean extends JsonObject
@@ -458,15 +472,15 @@ public class JsonTypedAccessTest
     @Test
     public void testAccess_MapEnumValues()
     {
-        MapBean bean = createJSON( "{'styles': {'a': 'FULL', 'b': 'SHORT'}}" ).as( MapBean.class );
-        assertEquals( Map.of( "a", TextStyle.FULL, "b", TextStyle.SHORT ), bean.styles() );
+        MapBean obj = createJSON( "{'styles': {'a': 'FULL', 'b': 'SHORT'}}" ).as( MapBean.class );
+        assertEquals( Map.of( "a", TextStyle.FULL, "b", TextStyle.SHORT ), obj.styles() );
     }
 
     @Test
     public void testAccess_MapMapStringValues()
     {
-        MapBean bean = createJSON( "{'messages': {'a':{'hello':'world'}, 'b':{}}}" ).as( MapBean.class );
-        assertEquals( Map.of( "a", Map.of( "hello", "world" ), "b", Map.of() ), bean.messages() );
+        MapBean obj = createJSON( "{'messages': {'a':{'hello':'world'}, 'b':{}}}" ).as( MapBean.class );
+        assertEquals( Map.of( "a", Map.of( "hello", "world" ), "b", Map.of() ), obj.messages() );
     }
 
     @Test
@@ -497,12 +511,14 @@ public class JsonTypedAccessTest
         assertEquals( Map.of( "a", 'A' ), two.recursive().get( 3 ).digits() );
     }
 
-    interface StreamBean extends JsonObject
+    interface StreamBean extends JsonValue
     {
 
         Stream<Integer> numbers();
 
         Stream<List<String>> lists();
+
+        Iterator<String> names();
     }
 
     @Test
@@ -517,6 +533,15 @@ public class JsonTypedAccessTest
     {
         StreamBean obj = createJSON( "{'lists':[['a','b'],['1','2']]}" ).as( StreamBean.class );
         assertEquals( List.of( List.of( "a", "b" ), List.of( "1", "2" ) ), obj.lists().collect( toList() ) );
+    }
+
+    @Test
+    public void testAccess_IteratorOfStrings()
+    {
+        StreamBean obj = createJSON( "{'names': ['Tom', 'Mary']}" ).as( StreamBean.class );
+        List<String> actual = new ArrayList<>();
+        obj.names().forEachRemaining( actual::add );
+        assertEquals( List.of( "Tom", "Mary" ), actual );
     }
 
     interface OptionalBean extends JsonValue
@@ -548,8 +573,93 @@ public class JsonTypedAccessTest
         assertEquals( List.of( "hello" ), obj.maybeList().orElse( List.of() ) );
     }
 
+    @Test
+    public void testAccess_ListsAreCached()
+    {
+        ListBean obj = createJSON( "{"
+            + "'names':['John', 'Paul', 'Ringo'],"
+            + "'ages':[1,2,3],"
+            + "'flags':[[true],[false]]"
+            + "}" ).as( ListBean.class );
+
+        assertFalse( obj.isAccessCached() );
+        assertNotSame( obj.names(), obj.names() );
+        ListBean cached = obj.withAccessCached().as( ListBean.class );
+        assertTrue( cached.isAccessCached() );
+        assertSame( cached.names(), cached.names() );
+        assertEquals( List.of( "John", "Paul", "Ringo" ), cached.names() );
+        // some more tests of the same
+        assertSame( cached.ages(), cached.ages() );
+        assertSame( cached.flags(), cached.flags() );
+        assertSame( cached.flags().get( 0 ), cached.flags().get( 0 ) );
+    }
+
+    @Test
+    public void testAccess_ObjectsAreCached()
+    {
+        SetBean obj = createJSON( "{'recursive': [{'ages':[1,2,3]}]}" ).withAccessCached().as( SetBean.class );
+        assertTrue( obj.isAccessCached() );
+        assertSame( obj.recursive().iterator().next().ages(), obj.recursive().iterator().next().ages() );
+
+        NestedBean obj2 = createJSON( "{'list':[{'b':{},'a':5}]}" ).withAccessCached().as( NestedBean.class );
+        assertSame( obj2.list(), obj2.list() );
+        assertSame( obj2.list().get( 0 ).getB(), obj2.list().get( 0 ).getB() );
+    }
+
+    @Test
+    public void testAccess_StreamsAreNeverCached()
+    {
+        StreamBean obj = createJSON( "{'numbers':[1,2,3], 'names':['Tim', 'Tom']}" ).withAccessCached()
+            .as( StreamBean.class );
+
+        assertTrue( obj.isAccessCached() );
+        assertNotSame( obj.numbers(), obj.numbers() );
+        assertNotSame( obj.names(), obj.names() );
+    }
+
+    interface UncachedBean extends JsonPrimitive
+    {
+
+        JsonNumber n();
+
+        Long time();
+
+        UncachedBean next();
+
+        JsonList<UncachedBean> list();
+
+        List<UncachedBean> list2();
+    }
+
+    @Test
+    public void testAccess_PrimitivesAreNeverCached()
+    {
+        UncachedBean obj = createJSON(
+            "{'n':42, 'time': 123456789, 'next':{'n':2}, 'list':[{'n':3}], 'list2':[{'n':4}]}" )
+                .withAccessCached().as( UncachedBean.class );
+
+        assertTrue( obj.isAccessCached() );
+        assertNotSame( obj.n(), obj.n() );
+        assertNotSame( obj.time(), obj.time() );
+        assertNotSame( obj.next(), obj.next() );
+
+        // in contrast:
+        assertSame( obj.list(), obj.list() );
+        assertNotSame( obj.list().get( 0 ), obj.list().get( 0 ) ); // JsonList
+                                                                   // is still
+                                                                   // lazy =>
+                                                                   // not cached
+
+        assertSame( obj.list2(), obj.list2() );
+        assertSame( obj.list2().get( 0 ), obj.list2().get( 0 ) ); // List is not
+                                                                  // lazy,
+                                                                  // elements
+                                                                  // are part of
+                                                                  // the List
+    }
+
     private static JsonResponse createJSON( String content )
     {
-        return new JsonResponse( content.replace( '\'', '"' ) );
+        return new JsonResponse( content.replace( '\'', '"' ), JsonTypedAccess.GLOBAL );
     }
 }


### PR DESCRIPTION
This is both rounding some rough edges of the API and adding a caching feature to the recently added typed access feature.

### Rounding Edges
* create virtual trees mainly via `JsonValue.of`
* create actual trees mainly via `JsonNode.of`
* `JsonValue` for `null` is now defined as constant `JsonValue.NULL`
* `JsonNode` also supports a `get(Sting path)` to access its sub-tree
* typed access now has "out of the box" support for `Iterator` and `Iterable`
* `JsonList` methods returns JDK collection API types return empty collection in case the source node is either undefined or defined `null` (would throw exception prior)
* `JsonMultiMap#toMap` return empty map in case the source node is undefined or defined `null`  (would throw exception prior)
* adding more tests

### Caching of Types Access
By default the typed access is **not** cached. This means accessing a property will recompute the return value on every access.

To switch to cached access one does:
```java
JsonValue cached = uncached.withAccessCached();
```
Caching is considered an optional feature of the API that might not be supported in all scenarios.
If a node (and with that any accessed node of its sub-tree) has effective caching on access can be checked using
```
if (obj.isAccessCached()) { ... }
```
The cache is part of the virtual tree and shared by all nodes created from the same root tree.