### PR TITLE
feat: JsonMixed abstraction, ignore nulls option in pretty-print

### DIFF
--- a/src/main/java/org/hisp/dhis/jsontree/JsonBuilder.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonBuilder.java
@@ -60,9 +60,25 @@ import static java.util.stream.StreamSupport.stream;
  */
 public interface JsonBuilder {
 
-    PrettyPrint MINIMIZED = new PrettyPrint( 0, 0, false, true );
+    PrettyPrint MINIMIZED = new PrettyPrint( 0, 0, false, true, false );
 
-    record PrettyPrint(int indentSpaces, int indentTabs, boolean spaceAfterColon, boolean retainOriginalDeclaration) {}
+    /**
+     * Pretty-printing configuration for the {@link JsonBuilder}.
+     * <p>
+     * If spaces and tabs are used the indent will first have tabs, then spaces.
+     *
+     * @param indentSpaces              number of spaces to use when indenting nested object members or array elements
+     * @param indentTabs                number of tabs to use when indenting nested object members or array elements
+     * @param spaceAfterColon           when true, the colon between member name and value has a space between the colon
+     *                                  and the member value
+     * @param retainOriginalDeclaration when true, elements or members provided as {@link JsonNode}s are kept "as is",
+     *                                  that means their JSON is included as returned by
+     *                                  {@link JsonNode#getDeclaration()}. When false their JSON is reformatted to
+     *                                  adhere to the pretty-printing configuration.
+     * @param excludeNullMembers        when true, null members are ommitted
+     */
+    record PrettyPrint(int indentSpaces, int indentTabs, boolean spaceAfterColon, boolean retainOriginalDeclaration,
+                       boolean excludeNullMembers) {}
 
     /**
      * Convenience method for ad-hoc creation of JSON object {@link JsonNode}. Use {@link JsonNode#getDeclaration()} to

--- a/src/main/java/org/hisp/dhis/jsontree/JsonMixed.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonMixed.java
@@ -1,0 +1,45 @@
+package org.hisp.dhis.jsontree;
+
+/**
+ * A {@link JsonValue} of unknown type that can be treated as any of the general JSON types for convenience.
+ *
+ * @see JsonValue
+ * 
+ * @author Jan Bernitt
+ * @since 0.8
+ */
+public interface JsonMixed extends JsonObject, JsonArray, JsonString, JsonNumber, JsonBoolean {
+
+    /**
+     * Lift an actual {@link JsonNode} tree to a virtual {@link JsonValue}.
+     *
+     * @param node non null
+     * @return the provided {@link JsonNode} as virtual {@link JsonValue}
+     */
+    static JsonMixed of( JsonNode node ) {
+        return new JsonVirtualTree( node, JsonTypedAccess.GLOBAL );
+    }
+
+    /**
+     * View the provided JSON string as virtual lazy evaluated tree.
+     *
+     * @param json JSON string
+     * @return virtual JSON tree root {@link JsonValue}
+     */
+    static JsonMixed of( String json ) {
+        return of( json, JsonTypedAccess.GLOBAL );
+    }
+
+    /**
+     * View the provided JSON string as virtual lazy evaluated tree using the provided {@link JsonTypedAccessStore} for
+     * mapping to Java method return types.
+     *
+     * @param json  a JSON string
+     * @param store mapping used to map JSON values to the Java method return types of abstract methods, when
+     *              {@code null} default mapping is used
+     * @return virtual JSON tree root {@link JsonValue}
+     */
+    static JsonMixed of( String json, JsonTypedAccessStore store ) {
+        return new JsonVirtualTree( json, store );
+    }
+}

--- a/src/main/java/org/hisp/dhis/jsontree/JsonValue.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonValue.java
@@ -67,7 +67,7 @@ public interface JsonValue {
     /**
      * Constant for JSON {@code null} value.
      */
-    JsonValue NULL = JsonResponse.NULL;
+    JsonValue NULL = JsonVirtualTree.NULL;
 
     /**
      * Lift an actual {@link JsonNode} tree to a virtual {@link JsonValue}.
@@ -76,7 +76,7 @@ public interface JsonValue {
      * @return the provided {@link JsonNode} as virtual {@link JsonValue}
      */
     static JsonValue of( JsonNode node ) {
-        return node == null ? NULL : of( node.getDeclaration() );
+        return node == null ? NULL : JsonMixed.of( node );
     }
 
     /**
@@ -99,7 +99,7 @@ public interface JsonValue {
      * @return virtual JSON tree root {@link JsonValue}
      */
     static JsonValue of( String json, JsonTypedAccessStore store ) {
-        return json == null || "null".equals( json ) ? NULL : new JsonResponse( json, store );
+        return json == null || "null".equals( json ) ? NULL : JsonMixed.of( json, store );
     }
 
     /**

--- a/src/test/java/org/hisp/dhis/jsontree/JsonAppenderTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonAppenderTest.java
@@ -118,6 +118,12 @@ class JsonAppenderTest {
     }
 
     @Test
+    void testObject_StringNull() {
+        assertJson( "{'s':null}", JsonBuilder.createObject( obj -> obj
+            .addString( "s", null ) ) );
+    }
+
+    @Test
     void testArray_String() {
         assertJson( "['hello']", JsonBuilder.createArray( arr -> arr
             .addString( "hello" ) ) );
@@ -251,6 +257,12 @@ class JsonAppenderTest {
     void testObject_JsonNode() {
         assertJson( "{'node':['a','b']}", JsonBuilder.createObject( obj -> obj
             .addMember( "node", JsonNode.of( "[\"a\",\"b\"]" ) ) ) );
+    }
+
+    @Test
+    void testObject_JsonNodeNull() {
+        assertJson( "{'node':null}", JsonBuilder.createObject( obj -> obj
+            .addMember( "node", JsonNode.NULL ) ) );
     }
 
     @Test

--- a/src/test/java/org/hisp/dhis/jsontree/JsonExpectedTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonExpectedTest.java
@@ -82,7 +82,7 @@ class JsonExpectedTest {
     void testIsA() {
         assertTrue( createJSON( "{'bar':'x'}" ).isA( JsonFoo.class ) );
         assertTrue( createJSON( "{'key':'x', 'value': 1}" ).isA( JsonEntry.class ) );
-        JsonResponse both = createJSON( "{'key':'x', 'value': 1, 'bar':'y'}" );
+        JsonMixed both = createJSON( "{'key':'x', 'value': 1, 'bar':'y'}" );
         assertTrue( both.isA( JsonFoo.class ) );
         assertTrue( both.isA( JsonEntry.class ) );
     }
@@ -192,7 +192,7 @@ class JsonExpectedTest {
         assertTrue( of.isInstance( obj ) );
     }
 
-    private static JsonResponse createJSON( String content ) {
-        return new JsonResponse( content.replace( '\'', '"' ), JsonTypedAccess.GLOBAL );
+    private static JsonMixed createJSON( String content ) {
+        return JsonMixed.of( content.replace( '\'', '"' ), JsonTypedAccess.GLOBAL );
     }
 }

--- a/src/test/java/org/hisp/dhis/jsontree/JsonListTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonListTest.java
@@ -107,7 +107,7 @@ class JsonListTest {
         assertEquals( List.of( 1, 2, 3 ), list.toListOfElementsThatExists( JsonNumber::intValue ) );
     }
 
-    private static JsonResponse createJSON( String content ) {
-        return new JsonResponse( content.replace( '\'', '"' ), JsonTypedAccess.GLOBAL );
+    private static JsonMixed createJSON( String content ) {
+        return JsonMixed.of( content.replace( '\'', '"' ), JsonTypedAccess.GLOBAL );
     }
 }

--- a/src/test/java/org/hisp/dhis/jsontree/JsonPrettyPrintTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonPrettyPrintTest.java
@@ -11,7 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class JsonPrettyPrintTest {
 
-    private static final JsonBuilder.PrettyPrint PRETTY = new JsonBuilder.PrettyPrint( 2, 0, true, false );
+    private static final JsonBuilder.PrettyPrint PRETTY = new JsonBuilder.PrettyPrint( 2, 0, true, false, false );
+    private static final JsonBuilder.PrettyPrint PRETTY_NO_NULL = new JsonBuilder.PrettyPrint( 2, 0, true, false,
+        true );
 
     @Test
     void testObject_BooleanPretty() {
@@ -74,5 +76,19 @@ class JsonPrettyPrintTest {
             }""";
         assertEquals( expected, JsonBuilder.createObject( PRETTY, obj -> obj
             .addMember( "test", JsonNode.of( "{\"a\":{\"b\":1}}" ) ) ).getDeclaration() );
+    }
+
+    @Test
+    void testObject_JsonNodePrettyNull() {
+        assertEquals( "{}", JsonBuilder.createObject( PRETTY_NO_NULL, obj -> obj
+            .addMember( "test", JsonNode.NULL ) ).getDeclaration() );
+    }
+
+    @Test
+    void testObject_Null() {
+        assertEquals( "{}", JsonBuilder.createObject( PRETTY_NO_NULL, obj -> obj
+            .addNumber( "num", null )
+            .addString( "str", null )
+            .addBoolean( "boo", null ) ).getDeclaration() );
     }
 }

--- a/src/test/java/org/hisp/dhis/jsontree/JsonTypedAccessTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonTypedAccessTest.java
@@ -53,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Tests the {@link JsonTypedAccessStore} implementation {@link JsonTypedAccess} by using it via {@link JsonResponse}
+ * Tests the {@link JsonTypedAccessStore} implementation {@link JsonTypedAccess} by using it via {@link JsonVirtualTree}
  * (it is the default implementation).
  *
  * @author Jan Bernitt
@@ -602,7 +602,7 @@ class JsonTypedAccessTest {
         assertSame( obj.list2().get( 0 ), obj.list2().get( 0 ) );
     }
 
-    private static JsonResponse createJSON( String content ) {
-        return new JsonResponse( content.replace( '\'', '"' ), JsonTypedAccess.GLOBAL );
+    private static JsonMixed createJSON( String content ) {
+        return JsonMixed.of( content.replace( '\'', '"' ), JsonTypedAccess.GLOBAL );
     }
 }

--- a/src/test/java/org/hisp/dhis/jsontree/JsonValueTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonValueTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Tests the static helpers of {@link JsonValue}.
@@ -41,8 +42,10 @@ class JsonValueTest {
 
     @Test
     void testOfJsonNode() {
-        JsonValue value = JsonValue.of( JsonBuilder.createObject( obj -> obj.addString( "foo", "bar" ) ) );
+        JsonNode node = JsonBuilder.createObject( obj -> obj.addString( "foo", "bar" ) );
+        JsonValue value = JsonValue.of( node );
         assertNotNull( value );
         assertEquals( "{\"foo\":\"bar\"}", value.toString() );
+        assertSame( node, value.node() );
     }
 }

--- a/src/test/java/org/hisp/dhis/jsontree/JsonVirtualTreeTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonVirtualTreeTest.java
@@ -40,12 +40,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Tests the basic correctness of {@link JsonResponse} which is the implementation of all core interfaces of the
+ * Tests the basic correctness of {@link JsonVirtualTree} which is the implementation of all core interfaces of the
  * {@link JsonValue} utility.
  *
  * @author Jan Bernitt
  */
-class JsonResponseTest {
+class JsonVirtualTreeTest {
 
     @Test
     void testCustomObjectTypeMultiMap() {
@@ -303,7 +303,7 @@ class JsonResponseTest {
         assertEquals( "Expected \" but reach EOI: {\"a:12}", map.toString() );
     }
 
-    private static JsonResponse createJSON( String content ) {
-        return new JsonResponse( content.replace( '\'', '"' ), JsonTypedAccess.GLOBAL );
+    private static JsonMixed createJSON( String content ) {
+        return JsonMixed.of( content.replace( '\'', '"' ), JsonTypedAccess.GLOBAL );
     }
 }


### PR DESCRIPTION
* Exposes former `JsonResponse` as interface `JsonMixed` and hides the implementation class now called `JsonVirtualTree`
* Adds a new `excludeNullMembers` `PrettyPrint` option to not include `null` values of object members