### PR TITLE
perf: wrapping a string in a JsonNode does not cause parse

### DIFF
--- a/src/main/java/org/hisp/dhis/jsontree/JsonNode.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonNode.java
@@ -80,6 +80,9 @@ public interface JsonNode extends Serializable {
 
     /**
      * Create a new lazily parsed {@link JsonNode} document.
+     * <p>
+     * JSON format issues are first encountered when the part of the document is accessed or skipped as part of working
+     * with the tree.
      *
      * @param json a JSON value/document
      * @return given document as {@link JsonNode} API

--- a/src/main/java/org/hisp/dhis/jsontree/JsonTree.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonTree.java
@@ -102,7 +102,9 @@ final class JsonTree implements Serializable {
 
         @Override
         public final String getDeclaration() {
-            return new String( tree.json, start, endIndex() - start );
+            return path.isEmpty() // avoid parse caused by endIndex() if root
+                ? new String( tree.json )
+                : new String( tree.json, start, endIndex() - start );
         }
 
         @Override

--- a/src/test/java/org/hisp/dhis/jsontree/JsonVirtualTreeTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonVirtualTreeTest.java
@@ -300,7 +300,7 @@ class JsonVirtualTreeTest {
     @Test
     void testToString_MalformedJson() {
         JsonMap<JsonNumber> map = createJSON( "{'a:12}" ).asMap( JsonNumber.class );
-        assertEquals( "Expected \" but reach EOI: {\"a:12}", map.toString() );
+        assertEquals( "Expected \" but reach EOI: {\"a:12}", map.get( "a" ).toString() );
     }
 
     private static JsonMixed createJSON( String content ) {


### PR DESCRIPTION
```java
JsonNode.of(json).getDeclaration();
```
should not cause full parse or skip of the json document since this might be used to incorporate or adopt JSON from a `String` into a `JsonNode` document. This is mostly a string copy operation where parsing the document would just be unnecessary temporary work. 

By using the full original JSON input of the root in case a root is printed via `getDeclaration()` the document does not need parsing in case it wasn't parsed already due to other tree usage.  