### PR TITLE
fix: only use initialized constants in default methods

### DIFF
--- a/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
@@ -218,7 +218,7 @@ public interface JsonObject extends JsonCollection {
             }
         } );
         return match.isEmpty()
-            ? JsonValue.NULL.as( type )
+            ? JsonVirtualTree.NULL.as( type )
             : JsonValue.of( match.get().getDeclaration() ).asObject().asObject( type );
     }
 

--- a/src/main/java/org/hisp/dhis/jsontree/JsonValue.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonValue.java
@@ -66,18 +66,13 @@ package org.hisp.dhis.jsontree;
 public interface JsonValue {
 
     /**
-     * Constant for JSON {@code null} value.
-     */
-    JsonValue NULL = JsonVirtualTree.NULL;
-
-    /**
      * Lift an actual {@link JsonNode} tree to a virtual {@link JsonValue}.
      *
      * @param node non null
      * @return the provided {@link JsonNode} as virtual {@link JsonValue}
      */
     static JsonValue of( JsonNode node ) {
-        return node == null ? NULL : JsonMixed.of( node );
+        return node == null ? JsonVirtualTree.NULL : JsonMixed.of( node );
     }
 
     /**
@@ -100,7 +95,7 @@ public interface JsonValue {
      * @return virtual JSON tree root {@link JsonValue}
      */
     static JsonValue of( String json, JsonTypedAccessStore store ) {
-        return json == null || "null".equals( json ) ? NULL : JsonMixed.of( json, store );
+        return json == null || "null".equals( json ) ? JsonVirtualTree.NULL : JsonMixed.of( json, store );
     }
 
     /**

--- a/src/test/java/org/hisp/dhis/jsontree/JsonObjectTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonObjectTest.java
@@ -1,0 +1,25 @@
+package org.hisp.dhis.jsontree;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for methods declared as default methods in {@link JsonObject}.
+ *
+ * @author Jan Bernitt
+ */
+class JsonObjectTest {
+
+    @Test
+    void testFind() {
+        //language=JSON
+        String json = """
+            {
+                "x":{ "foo": 1 }
+            }""";
+        JsonMixed root = JsonMixed.of( json );
+        assertTrue( root.find( JsonObject.class, obj -> obj.has( "foo" ) ).isObject() );
+        assertTrue( root.find( JsonObject.class, obj -> obj.has( "bar" ) ).isNull() );
+    }
+}


### PR DESCRIPTION
For some yet unknown reason the `NULL` constant in `JsonValue` is not initialized when used from a `default` method in `JsonObject` (which `extends` `JsonValue`). 

The best explanation I can come up with is that this is a corner case of initialization order where the constants of a super-interface are not necessarily initialized when calling a default method on a sub-interface. 

The easiest fix seemed to be to use the `JsonVirtualTree.NULL` constant directly.
The `JsonValue.NULL` constant got removed as it might otherwise be used in a similar way by classes extending the virtual tree types causing similar issues.