### PR TITLE
feat: better map key/value access

### DIFF
--- a/src/main/java/org/hisp/dhis/jsontree/JsonMultiMap.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonMultiMap.java
@@ -78,14 +78,15 @@ public interface JsonMultiMap<E extends JsonValue> extends JsonMap<JsonList<E>> 
             return Map.of();
         }
         Map<String, List<T>> res = new LinkedHashMap<>();
-        for ( String key : keys() ) {
-            List<T> list = get( key ).toList( mapper );
+        forEach( ( key, value ) -> {
+            List<T> list = value.toList( mapper );
             if ( order != null ) {
                 list = new ArrayList<>( list );
                 list.sort( order );
             }
             res.put( key, list );
-        }
+
+        } );
         return res;
     }
 

--- a/src/main/java/org/hisp/dhis/jsontree/JsonNode.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonNode.java
@@ -277,6 +277,22 @@ public interface JsonNode extends Serializable {
     /**
      * OBS! Only defined when this node is of type {@link JsonNodeType#OBJECT}).
      * <p>
+     * The keys are iterated in order of declaration in the underlying document.
+     * <p>
+     * The main reason to use this method over {@link #members()} is that values are not yet parsed into tree nodes if
+     * they haven't been parsed already. In that regard this can be more lightweight than using {@link #members()}.
+     *
+     * @return this {@link #value()} as a sequence of {@link String} keys
+     * @throws JsonTreeException if this node is not an object node that could have members
+     * @since 0.11
+     */
+    default Iterable<String> keys() {
+        throw new JsonTreeException( getType() + " node has no keys property." );
+    }
+
+    /**
+     * OBS! Only defined when this node is of type {@link JsonNodeType#OBJECT}).
+     * <p>
      * The members are iterated in order of declaration in the underlying document.
      *
      * @param cacheNodes true, to internally "remember" the members iterated over so far, false to only iterate without

--- a/src/test/java/org/hisp/dhis/jsontree/JsonMapTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonMapTest.java
@@ -3,6 +3,7 @@ package org.hisp.dhis.jsontree;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -23,54 +24,46 @@ class JsonMapTest {
     void testKeys_Undefined() {
         JsonMap<JsonString> obj = JsonMixed.of( "{}" ).getMap( "a", JsonString.class );
         JsonMap<JsonString> obj2 = JsonMixed.of( "null" ).getObject( "a" ).asMap( JsonString.class );
-        assertThrowsExactly( JsonPathException.class, obj::keys );
-        assertThrowsExactly( JsonPathException.class, obj2::keys );
-
-        // with default
-        assertEquals( Set.of(), obj.keys( Set.of() ) );
-        assertEquals( Set.of(), obj2.keys( Set.of() ) );
+        assertEquals(List.of(), obj.keys().toList() );
+        assertEquals(List.of(), obj2.keys().toList() );
     }
 
     @Test
     void testKeys_NoMapObject() {
         JsonMap<JsonString> obj = JsonMixed.of( "[1]" ).getMap( 0, JsonString.class );
-        JsonMap<JsonString> obj2 = JsonMixed.of( "null" ).asMap( JsonString.class );
+        JsonMap<JsonString> obj2 = JsonMixed.of( "1" ).asMap( JsonString.class );
         assertThrowsExactly( JsonTreeException.class, obj::keys );
         assertThrowsExactly( JsonTreeException.class, obj2::keys );
-
-        // with default
-        assertThrowsExactly( JsonTreeException.class, () -> obj.keys( Set.of() ) );
-        assertThrowsExactly( JsonTreeException.class, () -> obj2.keys( Set.of() ) );
     }
 
     @Test
     void testKeys_Empty() {
         JsonMap<JsonString> obj = JsonMixed.of( "{}" ).asMap( JsonString.class );
         JsonMap<JsonString> obj2 = JsonMixed.of( "{\"a\":{}}" ).getMap( "a", JsonString.class );
-        assertEquals( Set.of(), obj.keys() );
-        assertEquals( Set.of(), obj2.keys() );
+        assertEquals( List.of(), obj.keys().toList() );
+        assertEquals( List.of(), obj2.keys().toList() );
     }
 
     @Test
     void testKeys_NonEmpty() {
-        JsonMap<JsonString> obj = JsonMixed.of( "{\"b\":1,\"c\":2}" ).asMap( JsonString.class );
-        JsonMap<JsonString> obj2 = JsonMixed.of( "{\"a\":{\"b\":1,\"c\":2}}" ).getMap( "a", JsonString.class );
-        assertEquals( Set.of( "b", "c" ), obj.keys() );
-        assertEquals( Set.of( "b", "c" ), obj2.keys() );
+        JsonMap<JsonNumber> obj = JsonMixed.of( "{\"b\":1,\"c\":2}" ).asMap( JsonNumber.class );
+        JsonMap<JsonNumber> obj2 = JsonMixed.of( "{\"a\":{\"b\":1,\"c\":2}}" ).getMap( "a", JsonNumber.class );
+        assertEquals( List.of( "b", "c" ), obj.keys().toList() );
+        assertEquals( List.of( "b", "c" ), obj2.keys().toList() );
     }
 
     @Test
     void testForEach_Undefined() {
         JsonMap<JsonString> obj = JsonMixed.of( "{}" ).getMap( "a", JsonString.class );
         JsonMap<JsonString> obj2 = JsonMixed.of( "null" ).getObject( "a" ).asMap( JsonString.class );
-        assertThrowsExactly( JsonPathException.class, () -> obj.forEach( ( k, v ) -> fail() ) );
-        assertThrowsExactly( JsonPathException.class, () -> obj2.forEach( ( k, v ) -> fail() ) );
+        obj.forEach( ( k, v ) -> fail("Should not be called") );
+        obj2.forEach( ( k, v ) -> fail("Should not be called") );
     }
 
     @Test
     void testForEach_NoMapObject() {
         JsonMap<JsonString> obj = JsonMixed.of( "[1]" ).getMap( 0, JsonString.class );
-        JsonMap<JsonString> obj2 = JsonMixed.of( "null" ).asMap( JsonString.class );
+        JsonMap<JsonString> obj2 = JsonMixed.of( "1" ).asMap( JsonString.class );
         assertThrowsExactly( JsonTreeException.class, () -> obj.forEach( ( k, v ) -> fail() ) );
         assertThrowsExactly( JsonTreeException.class, () -> obj2.forEach( ( k, v ) -> fail() ) );
     }
@@ -85,8 +78,8 @@ class JsonMapTest {
 
     @Test
     void testForEach_NonEmpty() {
-        JsonMap<JsonString> obj = JsonMixed.of( "{\"b\":1,\"c\":2}" ).asMap( JsonString.class );
-        JsonMap<JsonString> obj2 = JsonMixed.of( "{\"a\":{\"b\":1,\"c\":2}}" ).getMap( "a", JsonString.class );
+        JsonMap<JsonNumber> obj = JsonMixed.of( "{\"b\":1,\"c\":2}" ).asMap( JsonNumber.class );
+        JsonMap<JsonNumber> obj2 = JsonMixed.of( "{\"a\":{\"b\":1,\"c\":2}}" ).getMap( "a", JsonNumber.class );
 
         Map<String, Object> actual = new HashMap<>();
         Map<String, Object> actual2 = new HashMap<>();
@@ -124,10 +117,23 @@ class JsonMapTest {
     void testViewAsMap_NonEmpty() {
         JsonMap<JsonArray> obj = JsonMixed.of( "{\"b\":[1],\"c\":[2]}" ).asMap( JsonArray.class );
         JsonMap<JsonArray> obj2 = JsonMixed.of( "{\"a\":{\"b\":[1],\"c\":[2]}}" ).getMap( "a", JsonArray.class );
-        assertEquals( Set.of( "b", "c" ), obj.viewAsMap( arr -> arr.get( 0 ) ).keys() );
-        assertEquals( Set.of( "b", "c" ), obj2.viewAsMap( arr -> arr.get( 0 ) ).keys() );
+        assertEquals( List.of( "b", "c" ), obj.viewAsMap( arr -> arr.get( 0 ) ).keys().toList() );
+        assertEquals( List.of( "b", "c" ), obj2.viewAsMap( arr -> arr.get( 0 ) ).keys().toList() );
         assertEquals( 1, obj.viewAsMap( arr -> arr.getNumber( 0 ) ).get( "b" ).intValue() );
         assertEquals( 1, obj2.viewAsMap( arr -> arr.getNumber( 0 ) ).get( "b" ).intValue() );
     }
 
+    @Test
+    void testViewAsMap_Keys() {
+        JsonMap<JsonArray> obj = JsonMixed.of( "{\"b\":[1],\"c\":[2]}" ).asMap( JsonArray.class );
+        JsonMap<JsonNumber> view = obj.viewAsMap( arr -> arr.getNumber( 0 ) );
+        assertEquals( List.of("b", "c"), view.keys().toList() );
+    }
+
+    @Test
+    void testViewAsMap_Values() {
+        JsonMap<JsonArray> obj = JsonMixed.of( "{\"b\":[1],\"c\":[2]}" ).asMap( JsonArray.class );
+        JsonMap<JsonNumber> view = obj.viewAsMap( arr -> arr.getNumber( 0 ) );
+        assertEquals( List.of(1, 2), view.values().map( JsonNumber::intValue ).toList() );
+    }
 }


### PR DESCRIPTION
Adds `Node#keys` to only iterate the keys (names) of an object's properties.
Based on this the `JsonMap` implements improved `keys()`, `values()` and `forEach`.

`JsonMap#keys` no longer returns a `Set` but a `Stream`. This is more in line with the virtual tree API as methods based on `keys()` will also no longer throw a `JsonPathException` in case the node does not exist. If the not does not exist or is defined `null` the `keys()` `Stream` is empty. 