### PR TITLE
feat: dependent required equals, auto enum validation, JSON of Path and Reader

### DIFF
--- a/src/main/java/org/hisp/dhis/jsontree/JsonAbstractArray.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonAbstractArray.java
@@ -1,6 +1,8 @@
 package org.hisp.dhis.jsontree;
 
+import org.hisp.dhis.jsontree.Validation.Rule;
 import org.hisp.dhis.jsontree.internal.Surly;
+import org.hisp.dhis.jsontree.validation.JsonValidator;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -110,5 +112,16 @@ public interface JsonAbstractArray<E extends JsonValue> extends JsonAbstractColl
      */
     default E first( Predicate<E> test ) {
         return stream().filter( test ).findFirst().orElseGet( () -> get( size() ) );
+    }
+
+    /**
+     * @param schema the schema to validate all elements of this array against
+     * @param rules optional set of {@link Rule}s to check, empty includes all
+     * @throws JsonSchemaException      in case this value does not match the given schema
+     * @throws IllegalArgumentException in case the given schema is not an interface
+     * @since 1.0
+     */
+    default void validateEach(Class<? extends JsonAbstractObject<?>> schema, Rule... rules) {
+        forEach( e -> JsonValidator.validate( e, schema, rules ) );
     }
 }

--- a/src/main/java/org/hisp/dhis/jsontree/JsonArray.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonArray.java
@@ -114,6 +114,8 @@ public interface JsonArray extends JsonAbstractArray<JsonValue> {
         return JsonAbstractCollection.asMultiMap( getObject( index ), as );
     }
 
+
+
     /**
      * Maps this array to a lazy transformed list view where each element of the original array is transformed by the
      * given function when accessed.

--- a/src/main/java/org/hisp/dhis/jsontree/JsonMixed.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonMixed.java
@@ -1,5 +1,8 @@
 package org.hisp.dhis.jsontree;
 
+import java.io.Reader;
+import java.nio.file.Path;
+
 import static org.hisp.dhis.jsontree.Validation.NodeType.ARRAY;
 import static org.hisp.dhis.jsontree.Validation.NodeType.BOOLEAN;
 import static org.hisp.dhis.jsontree.Validation.NodeType.INTEGER;
@@ -72,5 +75,23 @@ public interface JsonMixed extends JsonObject, JsonArray, JsonString, JsonNumber
      */
     static JsonMixed ofNonStandard( String json ) {
         return of( JsonNode.ofNonStandard( json ) );
+    }
+
+    /**
+     * @param file a JSON file in UTF-8 encoding
+     * @return root of the virtual tree representing the given JSON input
+     * @since 1.0
+     */
+    static JsonMixed of( Path file ) {
+        return of(JsonNode.of( file ));
+    }
+
+    /**
+     * @param json JSON input
+     * @return root of the virtual tree representing the given JSON input
+     * @since 1.0
+     */
+    static JsonMixed of( Reader json ) {
+        return of(JsonNode.of( json, null ));
     }
 }

--- a/src/main/java/org/hisp/dhis/jsontree/JsonValue.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonValue.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.jsontree;
 import org.hisp.dhis.jsontree.internal.Maybe;
 import org.hisp.dhis.jsontree.internal.Surly;
 
+import java.io.Reader;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -105,6 +107,24 @@ public interface JsonValue {
      */
     static JsonValue of( String json, JsonTypedAccessStore store ) {
         return json == null || "null".equals( json ) ? JsonVirtualTree.NULL : JsonMixed.of( json, store );
+    }
+
+    /**
+     * @param file a JSON file in UTF-8 encoding
+     * @return root of the virtual tree representing the given JSON input
+     * @since 1.0
+     */
+    static JsonValue of( Path file ) {
+        return of(JsonNode.of( file ));
+    }
+
+    /**
+     * @param json JSON input
+     * @return root of the virtual tree representing the given JSON input
+     * @since 1.0
+     */
+    static JsonValue of( Reader json ) {
+        return of(JsonNode.of( json, null ));
     }
 
     /**

--- a/src/main/java/org/hisp/dhis/jsontree/Validation.java
+++ b/src/main/java/org/hisp/dhis/jsontree/Validation.java
@@ -4,9 +4,7 @@ import org.hisp.dhis.jsontree.internal.Maybe;
 import org.hisp.dhis.jsontree.internal.Surly;
 
 import java.io.Serializable;
-import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -171,6 +169,9 @@ public @interface Validation {
 
     /**
      * Corresponds to JSON schema validation specified as {@code enum}.
+     * <p>
+     * If all values are strings and all start with a letter and none is {@code true}, {@code false} or {@code null}
+     * then the strings do not have to be quoted.
      *
      * @return value must be equal to one of the given JSON values
      */
@@ -182,6 +183,14 @@ public @interface Validation {
      * @return value must be equal to one of the value of the given enum
      */
     Class<? extends Enum> enumeration() default Enum.class;
+
+    /**
+     * {@link YesNo#AUTO} is not case-insensitive.
+     *
+     * @return to allow {@link #enumeration()} names to be of different case
+     * @since 1.0
+     */
+    YesNo caseInsensitive() default YesNo.AUTO;
 
     /*
      Validations for Strings

--- a/src/main/java/org/hisp/dhis/jsontree/validation/JsonValidator.java
+++ b/src/main/java/org/hisp/dhis/jsontree/validation/JsonValidator.java
@@ -1,6 +1,7 @@
 package org.hisp.dhis.jsontree.validation;
 
 import org.hisp.dhis.jsontree.JsonAbstractObject;
+import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonPathException;
 import org.hisp.dhis.jsontree.JsonSchemaException;

--- a/src/main/java/org/hisp/dhis/jsontree/validation/PropertyValidation.java
+++ b/src/main/java/org/hisp/dhis/jsontree/validation/PropertyValidation.java
@@ -113,18 +113,18 @@ record PropertyValidation(
     /**
      * Validations that apply to string nodes.
      *
-     * @param anyOfNames JSON string value must be one of the enum names, {@link Enum} is off
+     * @param anyOfStrings JSON string value must be one of the enum names
+     * @param caseInsensitive test {@link #anyOfStrings} with {@link String#equalsIgnoreCase(String)}
      * @param minLength  minimum length for the JSON string, negative is off
      * @param maxLength  maximum length for the JSON string, negative is off
      * @param pattern    JSON string must match the provided pattern, empty string is off
      */
-    record StringValidation(@SuppressWarnings( "rawtypes" )
-                            @Surly Class<? extends Enum> anyOfNames, int minLength, int maxLength,
-                            @Surly String pattern) {
-
+    record StringValidation(
+        @Surly Set<String> anyOfStrings, YesNo caseInsensitive, int minLength, int maxLength, @Surly String pattern) {
         StringValidation overlay( @Maybe StringValidation with ) {
             return with == null ? this : new StringValidation(
-                overlayE( anyOfNames, with.anyOfNames ),
+                overlayC( anyOfStrings, with.anyOfStrings ),
+                overlayY( caseInsensitive, with.caseInsensitive ),
                 overlayI( minLength, with.minLength ),
                 overlayI( maxLength, with.maxLength ),
                 overlayS( pattern, with.pattern ) );

--- a/src/test/java/org/hisp/dhis/jsontree/Assertions.java
+++ b/src/test/java/org/hisp/dhis/jsontree/Assertions.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.jsontree.validation;
+package org.hisp.dhis.jsontree;
 
 import org.hisp.dhis.jsontree.JsonAbstractObject;
 import org.hisp.dhis.jsontree.JsonMixed;
@@ -10,7 +10,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
-class Assertions {
+public class Assertions {
 
     public static Validation.Error assertValidationError( String actualJson,
         Class<? extends JsonAbstractObject<?>> schema,

--- a/src/test/java/org/hisp/dhis/jsontree/JsonReaderTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonReaderTest.java
@@ -1,0 +1,39 @@
+package org.hisp.dhis.jsontree;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JsonReaderTest {
+
+    @Test
+    void testReader_Mixed() {
+        String json = """
+            {"key": "😆"}""";
+        assertEquals( json, JsonMixed.of( new StringReader( json ) ).toJson() );
+    }
+
+    @Test
+    void testReader_Value() {
+        String json = """
+            {"key": "😆"}""";
+        assertEquals( json, JsonValue.of( new StringReader( json ) ).toJson() );
+    }
+
+    @Test
+    void testFile_Mixed() {
+        String json = """
+            { "min": -1.0e+28, "max": 1.0e+28 }""";
+        assertEquals( json, JsonMixed.of( Path.of("src/test/resources/suite/y_object_extreme_numbers.json") ).toJson() );
+    }
+
+    @Test
+    void testFile_Value() {
+        String json = """
+            { "min": -1.0e+28, "max": 1.0e+28 }""";
+        assertEquals( json, JsonValue.of( Path.of("src/test/resources/suite/y_object_extreme_numbers.json") ).toJson() );
+    }
+}

--- a/src/test/java/org/hisp/dhis/jsontree/example/JsonPatchTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/example/JsonPatchTest.java
@@ -1,0 +1,125 @@
+package org.hisp.dhis.jsontree.example;
+
+import org.hisp.dhis.jsontree.JsonMixed;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.jsontree.Required;
+import org.hisp.dhis.jsontree.Validation;
+import org.hisp.dhis.jsontree.Validation.Rule;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Map;
+import java.util.Set;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Validation.YesNo.YES;
+
+/**
+ * A test that shows how the JSON patch standard could be modeled.
+ */
+class JsonPatchTest {
+
+    public enum Op { ADD, REMOVE, REPLACE, COPY, MOVE, TEST }
+
+    @Retention( RUNTIME )
+    @Target( METHOD )
+    @Validation(pattern = "(\\/(([^\\/~])|(~[01]))*)")
+    @interface JsonPointer {}
+
+    public interface JsonPatch extends JsonObject {
+
+        @Required
+        @Validation(dependentRequired = {"=add", "=replace", "=copy", "=move", "=test"}, caseInsensitive = YES)
+        default Op getOperation() {
+            return getString( "op" ).parsed( Op::valueOf );
+        }
+
+        @JsonPointer
+        @Required
+        default String getPath() {
+            return getString( "path" ).string();
+        }
+
+        @Validation(dependentRequired = {"add", "replace", "test"})
+        default JsonMixed getValue() {
+            return get( "value", JsonMixed.class );
+        }
+
+        @JsonPointer
+        @Validation(dependentRequired = {"copy", "move"})
+        default String getFrom() {
+            return getString( "from" ).string();
+        }
+    }
+
+    @Test
+    void testAny_InvalidPath() {
+        assertValidationError( """
+            { "op": "remove", "path": "hello" }""", JsonPatch.class, Rule.PATTERN,
+            "(\\/(([^\\/~])|(~[01]))*)", "hello");
+    }
+
+    @Test
+    void testAny_MissingOp() {
+        assertValidationError( """
+            { "path": "/hello" }""", JsonPatch.class, Rule.REQUIRED, "op");
+    }
+
+    @Test
+    void testAny_InvalidOp() {
+        assertValidationError( """
+            { "op": "update", "path": "/hello" }""", JsonPatch.class, Rule.ENUM,
+            Set.of("ADD", "MOVE", "COPY", "REMOVE", "REPLACE", "TEST"), "update");
+    }
+
+    @Test
+    void testAny_MissingPath() {
+        assertValidationError( """
+            { "op": "remove"}""", JsonPatch.class, Rule.REQUIRED, "path");
+    }
+
+    @Test
+    void testAdd_MissingValue() {
+        assertValidationError( """
+            { "op": "add", "path": "/foo"}""", JsonPatch.class, Rule.DEPENDENT_REQUIRED,
+            Map.of("op", "add"), Set.of("value"), Set.of("value"));
+    }
+
+    @Test
+    void testReplace_MissingValue() {
+        assertValidationError( """
+            { "op": "replace", "path": "/foo"}""", JsonPatch.class, Rule.DEPENDENT_REQUIRED,
+            Map.of("op", "replace"), Set.of("value"), Set.of("value"));
+    }
+
+    @Test
+    void testTest_MissingValue() {
+        assertValidationError( """
+            { "op": "test", "path": "/foo"}""", JsonPatch.class, Rule.DEPENDENT_REQUIRED,
+            Map.of("op", "test"), Set.of("value"), Set.of("value"));
+    }
+
+    @Test
+    void testCopy_MissingFrom() {
+        assertValidationError( """
+            { "op": "copy", "path": "/foo"}""", JsonPatch.class, Rule.DEPENDENT_REQUIRED,
+            Map.of("op", "copy"), Set.of("from"), Set.of("from"));
+    }
+
+    @Test
+    void testMove_MissingFrom() {
+        assertValidationError( """
+            { "op": "move", "path": "/foo"}""", JsonPatch.class, Rule.DEPENDENT_REQUIRED,
+            Map.of("op", "move"), Set.of("from"), Set.of("from"));
+    }
+
+    @Test
+    void testMove_InvalidFrom() {
+        assertValidationError( """
+            { "op": "move", "from": "hello", "path":"/" }""", JsonPatch.class, Rule.PATTERN,
+            "(\\/(([^\\/~])|(~[01]))*)", "hello");
+    }
+}

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationDependentRequiredTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationDependentRequiredTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationEnumTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationEnumTest.java
@@ -1,0 +1,115 @@
+package org.hisp.dhis.jsontree.validation;
+
+import org.hisp.dhis.jsontree.JsonMixed;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.jsontree.Validation;
+import org.hisp.dhis.jsontree.Validation.Rule;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.ElementType;
+import java.util.Set;
+
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Validation.YesNo.YES;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Tests Validation of the @{@link Validation#enumeration()} and @{@link Validation#oneOfValues()} properties.
+ *
+ * @author Jan Bernitt
+ */
+class JsonValidationEnumTest {
+
+    public interface JsonEnumExampleA extends JsonObject {
+
+        @Validation(oneOfValues = {"hello", "world"})
+        default String getType() { return getString( "type" ).string(); }
+    }
+
+    public interface JsonEnumExampleB extends JsonObject {
+
+        @Validation(oneOfValues = {"\"yes\"", "true", "1", "\"no\"", "false", "0"})
+        default JsonMixed isOn() { return get( "on", JsonMixed.class ); }
+    }
+
+    public interface JsonEnumExampleC extends JsonObject {
+
+        @Validation(enumeration = ElementType.class )
+        default String getType() { return getString( "type" ).string(); }
+    }
+
+    public interface JsonEnumExampleD extends JsonObject {
+
+        @Validation(enumeration = ElementType.class, caseInsensitive = YES)
+        default String getType() { return getString( "type" ).string(); }
+    }
+
+    @Test
+    void testEnum_OneOfValuesPlain_OK() {
+        assertDoesNotThrow( () -> JsonMixed.of("""
+            {"type": "hello"}""").validate( JsonEnumExampleA.class )  );
+        assertDoesNotThrow( () -> JsonMixed.of("""
+            {"type": "world"}""").validate( JsonEnumExampleA.class )  );
+    }
+
+    @Test
+    void testEnum_OneOfValuesPlain_Invalid() {
+        assertValidationError( """
+            {"type": "joe"}""", JsonEnumExampleA.class, Rule.ENUM, Set.of("hello", "world"), "joe" );
+        assertValidationError( """
+            {"type": "HELLO"}""", JsonEnumExampleA.class, Rule.ENUM, Set.of("hello", "world"), "HELLO" );
+    }
+
+    @Test
+    void testEnum_OneOfValuesMixed_OK() {
+        assertDoesNotThrow( () -> JsonMixed.of("""
+            {"on": 1}""").validate( JsonEnumExampleB.class )  );
+        assertDoesNotThrow( () -> JsonMixed.of("""
+            {"on": true}""").validate( JsonEnumExampleB.class )  );
+        assertDoesNotThrow( () -> JsonMixed.of("""
+            {"on": "yes"}""").validate( JsonEnumExampleB.class )  );
+    }
+
+    @Test
+    void testEnum_OneOfValuesMixed_Invalid() {
+        assertValidationError( """
+            {"on": "1"}""", JsonEnumExampleB.class, Rule.ENUM,
+            Set.of("false", "1", "0", "true", "\"yes\"", "\"no\""), "\"1\"" );
+    }
+
+    @Test
+    void testEnum_Enumeration_OK() {
+        assertDoesNotThrow( () -> JsonMixed.of("""
+            {"type": "TYPE"}""").validate( JsonEnumExampleC.class )  );
+        assertDoesNotThrow( () -> JsonMixed.of("""
+            {"type": "METHOD"}""").validate( JsonEnumExampleC.class )  );
+    }
+
+    @Test
+    void testEnum_Enumeration_Invalid() {
+        Set<String> expectedValidValues = Set.of( "ANNOTATION_TYPE", "RECORD_COMPONENT", "TYPE_PARAMETER", "MODULE",
+            "TYPE", "TYPE_USE", "PARAMETER", "CONSTRUCTOR", "FIELD", "METHOD", "LOCAL_VARIABLE", "PACKAGE" );
+        assertValidationError( """
+            {"type": "type"}""", JsonEnumExampleC.class, Rule.ENUM, expectedValidValues, "type" );
+        assertValidationError( """
+            {"type": "oh no"}""", JsonEnumExampleC.class, Rule.ENUM, expectedValidValues, "oh no" );
+    }
+
+    @Test
+    void testEnum_EnumerationCaseInsensitive_OK() {
+        assertDoesNotThrow( () -> JsonMixed.of("""
+            {"type": "tyPe"}""").validate( JsonEnumExampleD.class )  );
+        assertDoesNotThrow( () -> JsonMixed.of("""
+            {"type": "Field"}""").validate( JsonEnumExampleD.class )  );
+    }
+
+    @Test
+    void testEnum_EnumerationCaseInsensitive_Invalid() {
+        Set<String> expectedValidValues = Set.of( "ANNOTATION_TYPE", "RECORD_COMPONENT", "TYPE_PARAMETER", "MODULE",
+            "TYPE", "TYPE_USE", "PARAMETER", "CONSTRUCTOR", "FIELD", "METHOD", "LOCAL_VARIABLE", "PACKAGE" );
+        assertValidationError( """
+            {"type": "RECORD"}""", JsonEnumExampleD.class, Rule.ENUM, expectedValidValues, "RECORD" );
+        assertValidationError( """
+            {"type": "oh no"}""", JsonEnumExampleD.class, Rule.ENUM, expectedValidValues, "oh no" );
+    }
+}

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationExclusiveMaximumTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationExclusiveMaximumTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationExclusiveMinimumTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationExclusiveMinimumTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMaxItemsTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMaxItemsTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.hisp.dhis.jsontree.Validation.YesNo.YES;
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMaxLengthTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMaxLengthTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Set;
 
 import static org.hisp.dhis.jsontree.Validation.YesNo.YES;
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMaxPropertiesTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMaxPropertiesTest.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.hisp.dhis.jsontree.Validation.YesNo.YES;
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMaximumTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMaximumTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMinItemsTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMinItemsTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.hisp.dhis.jsontree.Validation.YesNo.NO;
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMinLengthTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMinLengthTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Set;
 
 import static org.hisp.dhis.jsontree.Validation.YesNo.NO;
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMinPropertiesTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMinPropertiesTest.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.hisp.dhis.jsontree.Validation.YesNo.NO;
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMinimumTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMinimumTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMiscCollectionTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMiscCollectionTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMiscDeepGraphTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMiscDeepGraphTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Set;
 
 import static org.hisp.dhis.jsontree.Validation.YesNo.YES;
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMiscMetaAnnotationTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMiscMetaAnnotationTest.java
@@ -11,7 +11,7 @@ import static org.hisp.dhis.jsontree.Validation.Rule.MAX_LENGTH;
 import static org.hisp.dhis.jsontree.Validation.Rule.MIN_LENGTH;
 import static org.hisp.dhis.jsontree.Validation.Rule.REQUIRED;
 import static org.hisp.dhis.jsontree.Validation.YesNo.YES;
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 
 class JsonValidationMiscMetaAnnotationTest {
 

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMiscTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMiscTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.RetentionPolicy;
 
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JsonValidationMiscTest {

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMiscTypeUseTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMiscTypeUseTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 
 class JsonValidationMiscTypeUseTest {
 

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMultipleOfTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMultipleOfTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationPatternTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationPatternTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationRequiredTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationRequiredTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationUniqueItemsTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationUniqueItemsTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.hisp.dhis.jsontree.Validation.YesNo.YES;
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationValidatorTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationValidatorTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import static org.hisp.dhis.jsontree.validation.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**


### PR DESCRIPTION
Adds a couple of small features to complete 1.0 milestone

* dependent requires with equals
* Java `enum` typed properties are automatically validated against the enum constants
* new `@Validation#caseInsensitive()` to match enumeration constants case insensitive
* `JsonValue#of(Reader)` and `JsonValue#of(Path)`
* `JsonMixed#of(Reader)` and `JsonMixed#of(Path)`