### PR TITLE
chore: Version 1.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <packaging>jar</packaging>
     <name>DHIS JSON Tree</name>
     <url>https://github.com/dhis2/json-tree</url>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.8.1</version>
 
     <developers>
         <developer>


### PR DESCRIPTION
Changes to version 1.8.1 to force a RELEASE publication and test the setup for the new Central Publisher Portal