### PR TITLE
feat: collapsable inner records for to(Class) access

### DIFF
--- a/src/main/java/org/hisp/dhis/jsontree/Collapsed.java
+++ b/src/main/java/org/hisp/dhis/jsontree/Collapsed.java
@@ -10,10 +10,19 @@ import java.lang.annotation.Target;
  * Record}s whose components should be treated as if they were directly defined in the parent record
  * type when mapping JSON to Java using {@link JsonValue#to(Class)}.
  *
- * <p>Collapsing can be used to compose structures in Java without requiring that the JSON input has
- * the same structure. Since records do not allow for inheritance this is an alternative way to get
- * to a similar goal. In contrast to inheritance collapsed composition supports the equivalent of
- * multi-inheritance.
+ * <p>Collapsing can e.g. be used to access a "flat" JSON object with many properties as a Java
+ * record which uses inner records to group those properties without the need to mirror that
+ * grouping in JSON.
+ *
+ * <p>Since records do not allow for inheritance collapsing inner records can be used to compose
+ * structures that certain groups of properties without the need to duplicate the components. This
+ * is important as it still allows to write code that operates on one of such groups of properties
+ * in a way that inheritance would without the need to duplicate the code that can handle data
+ * having those properties. In contrast to inheritance collapsed composition supports the equivalent
+ * of multiple-inheritance simply by having multiple inner collapsed record properties.
+ *
+ * <p>Please note that ATM records with generics are not supported simply to keep the implementation
+ * simple.
  *
  * @author Jan Bernitt
  * @since 1.9

--- a/src/main/java/org/hisp/dhis/jsontree/Collapsed.java
+++ b/src/main/java/org/hisp/dhis/jsontree/Collapsed.java
@@ -1,0 +1,23 @@
+package org.hisp.dhis.jsontree;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation for {@link java.lang.reflect.RecordComponent}s that are themselves {@link
+ * Record}s whose components should be treated as if they were directly defined in the parent record
+ * type when mapping JSON to Java using {@link JsonValue#to(Class)}.
+ *
+ * <p>Collapsing can be used to compose structures in Java without requiring that the JSON input has
+ * the same structure. Since records do not allow for inheritance this is an alternative way to get
+ * to a similar goal. In contrast to inheritance collapsed composition supports the equivalent of
+ * multi-inheritance.
+ *
+ * @author Jan Bernitt
+ * @since 1.9
+ */
+@Target(ElementType.RECORD_COMPONENT)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Collapsed {}

--- a/src/main/java/org/hisp/dhis/jsontree/JsonAbstractObject.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonAbstractObject.java
@@ -125,19 +125,9 @@ public interface JsonAbstractObject<E extends JsonValue> extends JsonAbstractCol
    * @since 0.11 (as Stream)
    */
   @TerminalOp(canBeUndefined = true, mustBeObject = true)
-  default Stream<Text> keys() {
-    if (isUndefined() || isEmpty()) return Stream.empty();
-    return node().keys().stream();
-  }
-
-  /**
-   * @return a stream of the map/object values in order of their declaration
-   * @throws JsonTreeException in case this node does exist but is not an object node
-   * @since 0.11
-   */
-  @TerminalOp(canBeUndefined = true, mustBeObject = true)
-  default Stream<E> values() {
-    return entries();
+  default Streamable.Sized<Text> keys() {
+    if (isUndefined() || isEmpty()) return Streamable.empty();
+    return node().keys();
   }
 
   /**
@@ -146,9 +136,9 @@ public interface JsonAbstractObject<E extends JsonValue> extends JsonAbstractCol
    * @since 0.11
    */
   @TerminalOp(canBeUndefined = true, mustBeObject = true)
-  default Stream<E> entries() {
-    if (isUndefined() || isEmpty()) return Stream.empty();
-    return node().keys().stream().map(this::get);
+  default Streamable.Sized<E> entries() {
+    if (isUndefined() || isEmpty()) return Streamable.empty();
+    return node().keys().map(this::get);
   }
 
   /**

--- a/src/main/java/org/hisp/dhis/jsontree/JsonAccess.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonAccess.java
@@ -267,8 +267,8 @@ public final class JsonAccess implements JsonAccessors {
     JsonAccessor<?> elements = accessors.accessor(getRawType(elementType));
     // auto-box simple values in a 1 element sequence
     if (!stream.isArray()) return Stream.of(elements.access(stream, as, accessors));
-    return stream.stream(Index.AUTO_SKIP)
-        .map(e -> elements.access(e.as(JsonMixed.class), elementType, accessors));
+    return stream.values(Index.AUTO_SKIP)
+        .map(e -> elements.access(e.as(JsonMixed.class), elementType, accessors)).stream();
   }
 
   @SuppressWarnings({"java:S1168", "java:S1452"})

--- a/src/main/java/org/hisp/dhis/jsontree/JsonAccess.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonAccess.java
@@ -299,6 +299,7 @@ public final class JsonAccess implements JsonAccessors {
    * @param components the components in that constructor to pass as args
    * @param defaults default arguments if the component is undefined in JSON, null of no defaults
    *     are available (taken from a constant with name {@code DEFAULT}).
+   * @param collapsed true, if the component was annotated with {@link Collapsed}
    * @param of a static method to construct a record from a single argument (typical {@code
    *     of}-method)
    * @param ofArgType the generic argument type of the {@link #of()}-method
@@ -307,6 +308,7 @@ public final class JsonAccess implements JsonAccessors {
       MethodHandle constructor,
       RecordComponent[] components,
       Object[] defaults,
+      boolean[] collapsed,
       MethodHandle of,
       Type ofArgType) {}
 
@@ -340,11 +342,12 @@ public final class JsonAccess implements JsonAccessors {
 
     Object[] args = new Object[components.length];
     Object[] defaults = newRecord.defaults;
+    boolean[] collapsed = newRecord.collapsed;
     boolean hasDefaults = defaults != null;
     if (obj.isObject()) {
       for (int i = 0; i < components.length; i++) {
         RecordComponent c = components[i];
-        JsonMixed cValue = obj.get(c.getName());
+        JsonMixed cValue = collapsed[i] ? obj : obj.get(c.getName());
         args[i] =
             hasDefaults && cValue.isUndefined()
                 ? defaults[i]
@@ -353,7 +356,7 @@ public final class JsonAccess implements JsonAccessors {
     } else if (obj.isArray()) {
       for (int i = 0; i < components.length; i++) {
         RecordComponent c = components[i];
-        JsonMixed cValue = obj.get(i);
+        JsonMixed cValue = collapsed[i] ? obj : obj.get(i);
         args[i] =
             hasDefaults && cValue.isUndefined()
                 ? defaults[i]
@@ -399,6 +402,9 @@ public final class JsonAccess implements JsonAccessors {
       throw new JsonAccessException(
           "JSON cannot be mapped to Java record %s, canonical constructor is not accessible"
               .formatted(type.getSimpleName()));
+    boolean[] collapsed = new boolean[components.length];
+    for (int i = 0; i < components.length; i++)
+      collapsed[i] = components[i].isAnnotationPresent(Collapsed.class);
     MethodHandle ofMethod = null;
     Type ofMethodArgType = null;
     if (components.length > 1) {
@@ -411,7 +417,7 @@ public final class JsonAccess implements JsonAccessors {
         }
       }
     }
-    return new NewRecord(canonical, components, defaults(type), ofMethod, ofMethodArgType);
+    return new NewRecord(canonical, components, defaults(type), collapsed, ofMethod, ofMethodArgType);
   }
 
   private static MethodHandle constructor(

--- a/src/main/java/org/hisp/dhis/jsontree/JsonArray.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonArray.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.jsontree;
 import static org.hisp.dhis.jsontree.JsonNode.Index.AUTO;
 import static org.hisp.dhis.jsontree.JsonNode.Index.SKIP;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.DoubleStream;
@@ -56,27 +57,6 @@ public interface JsonArray extends JsonAbstractArray<JsonMixed> {
     return this; // return type override
   }
 
-  @Override
-  @TerminalOp(canBeUndefined = true, mustBeArray = true)
-  default Stream<JsonMixed> stream() {
-    return stream(AUTO);
-  }
-
-  /**
-   * @implNote This utilizes {@link JsonNode#elements(Index)} avoiding map lookups for each element.
-   *     On {@link JsonAbstractArray} level this cannot be done as the node cannot be {@link
-   *     JsonNode#lift(JsonAccessors)} ed to the unknown generic target type.
-   * @param index the strategy to apply when it comes to node lookup and indexing
-   * @since 1.9
-   */
-  @TerminalOp(canBeUndefined = true, mustBeArray = true)
-  default Stream<JsonMixed> stream(JsonNode.Index index) {
-    JsonNode node = nodeIfExists();
-    if (node == null || node.isNull()) return Stream.empty();
-    JsonAccessors accessors = getAccessors();
-    return node.elements(index).stream().map(n -> n.lift(accessors));
-  }
-
   /**
    * Index access to the array.
    *
@@ -89,6 +69,41 @@ public interface JsonArray extends JsonAbstractArray<JsonMixed> {
    */
   <E extends JsonValue> E get(int index, Class<E> as);
 
+  @Override
+  @TerminalOp(canBeUndefined = true, mustBeArray = true)
+  default Stream<JsonMixed> stream() {
+    return stream(AUTO);
+  }
+
+  /**
+   * @implNote This utilizes {@link JsonNode#elements(Index)} avoiding map lookups for each element.
+   *     On {@link JsonAbstractArray} level this cannot be done as the node cannot be {@link
+   *     JsonNode#lift(JsonAccessors)} ed to the unknown generic target type.
+   * @param index the strategy to apply when it comes to node lookup and indexing
+   * @throws JsonTreeException if this node exist but is not an array or null node
+   * @since 1.9
+   */
+  @TerminalOp(canBeUndefined = true, mustBeArray = true)
+  default Stream<JsonMixed> stream(JsonNode.Index index) {
+    JsonNode node = nodeIfExists();
+    if (node == null || node.isNull()) return Stream.empty();
+    JsonAccessors accessors = getAccessors();
+    return node.elements(index).stream().map(n -> n.lift(accessors));
+  }
+
+  /**
+   * @return this arrays values as {@link org.hisp.dhis.jsontree.Streamable.Sized}
+   * @throws JsonTreeException if this node exist but is not an array or null node
+   * @since 1.9
+   */
+  @TerminalOp(canBeUndefined = true, mustBeArray = true)
+  default Streamable.Sized<JsonMixed> values() {
+    JsonNode node = nodeIfExists();
+    if (node == null || node.isNull()) return Streamable.empty();
+    JsonAccessors accessors = getAccessors();
+    return node.elements(SKIP).map(n -> n.lift(accessors));
+  }
+
   /**
    * @return the array elements as a uniform list of {@link String}
    * @throws JsonTreeException in case the node is not an array or the array has mixed elements
@@ -97,7 +112,7 @@ public interface JsonArray extends JsonAbstractArray<JsonMixed> {
   default List<String> stringValues() {
     JsonNode node = nodeIfExists();
     if (node == null || node.isNull()) return List.of();
-    return node.elements(JsonNode.Index.SKIP).stream()
+    return node.elements(SKIP)
         .map(JsonNode::textValue)
         .map(Text::toString)
         .toList();
@@ -111,18 +126,7 @@ public interface JsonArray extends JsonAbstractArray<JsonMixed> {
   default List<Boolean> booleanValues() {
     JsonNode node = nodeIfExists();
     if (node == null || node.isNull()) return List.of();
-    return node.elements(JsonNode.Index.SKIP).stream().map(JsonNode::booleanValue).toList();
-  }
-
-  @TerminalOp(canBeUndefined = true, mustBeArray = true)
-  default <E> List<E> values(Function<String, E> f) {
-    JsonNode node = nodeIfExists();
-    if (node == null || node.isNull()) return List.of();
-    return node.elements(JsonNode.Index.SKIP).stream()
-        .map(JsonNode::textValue)
-        .map(Text::toString)
-        .map(f)
-        .toList();
+    return node.elements(SKIP).map(JsonNode::booleanValue).toList();
   }
 
   /**
@@ -168,6 +172,17 @@ public interface JsonArray extends JsonAbstractArray<JsonMixed> {
   @TerminalOp(canBeUndefined = true, mustBeArray = true)
   default <E> Stream<E> streamValues(Class<E> to) {
     return stream(SKIP).map(e -> e.to(to));
+  }
+
+  @TerminalOp(canBeUndefined = true, mustBeArray = true)
+  default <E> List<E> values(Function<String, E> f) {
+    JsonNode node = nodeIfExists();
+    if (node == null || node.isNull()) return List.of();
+    return node.elements(SKIP)
+        .map(JsonNode::textValue)
+        .map(Text::toString)
+        .map(f)
+        .toList();
   }
 
   /**

--- a/src/main/java/org/hisp/dhis/jsontree/JsonArray.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonArray.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.jsontree;
 import static org.hisp.dhis.jsontree.JsonNode.Index.AUTO;
 import static org.hisp.dhis.jsontree.JsonNode.Index.SKIP;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.DoubleStream;
@@ -37,6 +38,7 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import org.hisp.dhis.jsontree.JsonNode.Index;
+import org.hisp.dhis.jsontree.internal.NotNull;
 import org.hisp.dhis.jsontree.internal.TerminalOp;
 
 /**
@@ -70,24 +72,14 @@ public interface JsonArray extends JsonAbstractArray<JsonMixed> {
 
   @Override
   @TerminalOp(canBeUndefined = true, mustBeArray = true)
-  default Stream<JsonMixed> stream() {
-    return stream(AUTO);
+  default @NotNull Iterator<JsonMixed> iterator() {
+    return values(AUTO).iterator();
   }
 
-  /**
-   * @implNote This utilizes {@link JsonNode#elements(Index)} avoiding map lookups for each element.
-   *     On {@link JsonAbstractArray} level this cannot be done as the node cannot be {@link
-   *     JsonNode#lift(JsonAccessors)} ed to the unknown generic target type.
-   * @param index the strategy to apply when it comes to node lookup and indexing
-   * @throws JsonTreeException if this node exist but is not an array or null node
-   * @since 1.9
-   */
+  @Override
   @TerminalOp(canBeUndefined = true, mustBeArray = true)
-  default Stream<JsonMixed> stream(JsonNode.Index index) {
-    JsonNode node = nodeIfExists();
-    if (node == null || node.isNull()) return Stream.empty();
-    JsonAccessors accessors = getAccessors();
-    return node.elements(index).stream().map(n -> n.lift(accessors));
+  default Stream<JsonMixed> stream() {
+    return values(AUTO).stream();
   }
 
   /**

--- a/src/main/java/org/hisp/dhis/jsontree/JsonArray.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonArray.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.jsontree;
 import static org.hisp.dhis.jsontree.JsonNode.Index.AUTO;
 import static org.hisp.dhis.jsontree.JsonNode.Index.SKIP;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.DoubleStream;
@@ -92,16 +91,33 @@ public interface JsonArray extends JsonAbstractArray<JsonMixed> {
   }
 
   /**
+   * @see #values(Index)
+   * @since 1.9
+   */
+  @TerminalOp(canBeUndefined = true, mustBeArray = true)
+  default Streamable.Sized<JsonMixed> values() {
+    return values(SKIP);
+  }
+
+  /**
+   * @see #values()
+   * @since 1.9
+   */
+  default <T> Streamable.Sized<T> values(Class<T> to) {
+    return values().map(e -> e.to(to));
+  }
+
+  /**
    * @return this arrays values as {@link org.hisp.dhis.jsontree.Streamable.Sized}
    * @throws JsonTreeException if this node exist but is not an array or null node
    * @since 1.9
    */
   @TerminalOp(canBeUndefined = true, mustBeArray = true)
-  default Streamable.Sized<JsonMixed> values() {
+  default Streamable.Sized<JsonMixed> values(JsonNode.Index index) {
     JsonNode node = nodeIfExists();
     if (node == null || node.isNull()) return Streamable.empty();
     JsonAccessors accessors = getAccessors();
-    return node.elements(SKIP).map(n -> n.lift(accessors));
+    return node.elements(index).map(n -> n.lift(accessors));
   }
 
   /**
@@ -160,41 +176,6 @@ public interface JsonArray extends JsonAbstractArray<JsonMixed> {
     JsonNode node = nodeIfExists();
     if (node == null || node.isNull()) return DoubleStream.empty();
     return node.elements(SKIP).stream().mapToDouble(JsonNode::doubleValue);
-  }
-
-  /**
-   * Uses {@link #getAccessors()} for type conversion.
-   *
-   * @param to element target type
-   * @return a stream of all array values accessed as the given type in the order defined in JSON
-   * @since 1.9
-   */
-  @TerminalOp(canBeUndefined = true, mustBeArray = true)
-  default <E> Stream<E> streamValues(Class<E> to) {
-    return stream(SKIP).map(e -> e.to(to));
-  }
-
-  @TerminalOp(canBeUndefined = true, mustBeArray = true)
-  default <E> List<E> values(Function<String, E> f) {
-    JsonNode node = nodeIfExists();
-    if (node == null || node.isNull()) return List.of();
-    return node.elements(SKIP)
-        .map(JsonNode::textValue)
-        .map(Text::toString)
-        .map(f)
-        .toList();
-  }
-
-  /**
-   * Uses {@link #getAccessors()} for type conversion.
-   *
-   * @param to element target type
-   * @return a list of all array values accessed as the given type in the order defined in JSON
-   * @since 1.9
-   */
-  @TerminalOp(canBeUndefined = true, mustBeArray = true)
-  default <E> List<E> listValues(Class<E> to) {
-    return streamValues(to).toList();
   }
 
   default JsonMixed get(int index) {

--- a/src/main/java/org/hisp/dhis/jsontree/JsonDiff.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonDiff.java
@@ -200,7 +200,7 @@ public record JsonDiff(JsonValue expected, JsonValue actual, List<Difference> di
       JsonObject e, JsonObject a, Mode mode, Consumer<Difference> add, PropertyInfo p) {
     if (!p.anyAdditional(mode.objects.anyAdditional)) {
       // list all extra members
-      a.keys()
+      a.keys().stream()
           .filter(not(e::has))
           .forEach(key -> add.accept(new Difference(Type.MORE, e.get(key), a.get(key))));
     }
@@ -211,7 +211,7 @@ public record JsonDiff(JsonValue expected, JsonValue actual, List<Difference> di
     } else {
       // exact order
       Iterator<Text> eKeys = e.keys().iterator();
-      Iterator<Text> aKeys = a.keys().filter(e::has).iterator();
+      Iterator<Text> aKeys = a.keys().stream().filter(e::has).iterator();
       while (eKeys.hasNext() && aKeys.hasNext()) {
         Text eKey = eKeys.next();
         Text aKey = aKeys.next();

--- a/src/main/java/org/hisp/dhis/jsontree/JsonMap.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonMap.java
@@ -51,7 +51,7 @@ public interface JsonMap<E extends JsonValue> extends JsonAbstractObject<E> {
    * @since 0.11
    */
   default <T> Map<String, T> toMap(Function<E, T> toValue) {
-    return entries().collect(Collectors.toMap(e -> e.getKey().toString(), toValue));
+    return entries().stream().collect(Collectors.toMap(e -> e.getKey().toString(), toValue));
   }
 
   /**

--- a/src/main/java/org/hisp/dhis/jsontree/JsonMixed.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonMixed.java
@@ -27,8 +27,7 @@ import org.hisp.dhis.jsontree.internal.NotNull;
  */
 @Validation(type = {OBJECT, ARRAY, STRING, NUMBER, INTEGER, BOOLEAN})
 @Validation.Ignore
-public interface JsonMixed
-    extends JsonObject, JsonArray, JsonString, JsonNumber, JsonBoolean, JsonInteger {
+public interface JsonMixed extends JsonObject, JsonArray, JsonPrimitive {
 
   /**
    * Lift an actual {@link JsonNode} tree to a virtual {@link JsonValue}.

--- a/src/main/java/org/hisp/dhis/jsontree/JsonNode.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonNode.java
@@ -576,7 +576,7 @@ public interface JsonNode
    * @return this {@link #value()} as a sequence of {@link Entry}s
    * @throws JsonTreeException if this node is not an object node that could have members
    */
-  default Streamable<JsonNode> members() {
+  default Streamable.Sized<JsonNode> members() {
     throw notA(OBJECT, this, "members()");
   }
 
@@ -593,7 +593,7 @@ public interface JsonNode
    * @throws JsonTreeException if this node is not an object node that could have members
    * @since 0.11
    */
-  default Streamable<Text> keys() {
+  default Streamable.Sized<Text> keys() {
     throw notA(OBJECT, this, "keys()");
   }
 
@@ -604,7 +604,7 @@ public interface JsonNode
    * @throws JsonTreeException if this node is not an object node that could have members
    * @since 1.2
    */
-  default Streamable<JsonPath> paths() {
+  default Streamable.Sized<JsonPath> paths() {
     throw notA(OBJECT, this, "paths()");
   }
 
@@ -619,7 +619,7 @@ public interface JsonNode
    *     internally will be reused and returned by the iterator.
    * @throws JsonTreeException if this node is not an object node that could have members
    */
-  default Streamable<JsonNode> members(Index index) {
+  default Streamable.Sized<JsonNode> members(Index index) {
     throw notA(OBJECT, this, "members(Index)");
   }
 
@@ -674,7 +674,7 @@ public interface JsonNode
    * @return this {@link #value()} as as {@link Stream}
    * @throws JsonTreeException if this node is not an array node that could have elements
    */
-  default Streamable<JsonNode> elements() {
+  default Streamable.Sized<JsonNode> elements() {
     throw notA(ARRAY, this, "elements()");
   }
 
@@ -689,7 +689,7 @@ public interface JsonNode
    *     already exist internally will be reused and returned by the iterator.
    * @throws JsonTreeException if this node is not an array node that could have elements
    */
-  default Streamable<JsonNode> elements(Index index) {
+  default Streamable.Sized<JsonNode> elements(Index index) {
     throw notA(ARRAY, this, "elements(Index)");
   }
 
@@ -702,7 +702,7 @@ public interface JsonNode
    * @throws JsonTreeException if this node is not an array node that could have elements
    * @since 1.9
    */
-  default Streamable<Text> values() {
+  default Streamable.Sized<Text> values() {
     throw notA(ARRAY, this, "values()");
   }
 

--- a/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
@@ -97,6 +97,16 @@ public interface JsonObject extends JsonAbstractObject<JsonMixed> {
   }
 
   /**
+   * @param of an object type
+   * @return a list of the properties in the given object type including those collapsed down from
+   *     {@link Collapsed} inner {@link Record}s
+   * @since 1.9
+   */
+  static List<Property> collapsedProperties(Class<? extends Record> of) {
+    return JsonVirtualTree.collapsedProperties(of);
+  }
+
+  /**
    * Access to object fields by name.
    *
    * <p>Note that this neither checks if a field exist nor if it has the assumed type.

--- a/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
@@ -170,9 +170,13 @@ public interface JsonObject extends JsonAbstractObject<JsonMixed> {
     return JsonAbstractCollection.asMultiMap(getObject(name), as);
   }
 
+  /**
+   * @see #entries(Index)
+   * @since 1.9
+   */
   @Override
   @TerminalOp(canBeUndefined = true, mustBeObject = true)
-  default Stream<JsonMixed> entries() {
+  default Streamable.Sized<JsonMixed> entries() {
     return entries(AUTO);
   }
 
@@ -189,10 +193,10 @@ public interface JsonObject extends JsonAbstractObject<JsonMixed> {
    * @since 1.9
    */
   @TerminalOp(canBeUndefined = true, mustBeObject = true)
-  default Stream<JsonMixed> entries(JsonNode.Index index) {
-    if (isUndefined() || isEmpty()) return Stream.empty();
+  default Streamable.Sized<JsonMixed> entries(JsonNode.Index index) {
+    if (isUndefined() || isEmpty()) return Streamable.empty();
     JsonAccessors accessors = getAccessors();
-    return node().members(index).stream().map(e -> e.lift(accessors));
+    return node().members(index).map(e -> e.lift(accessors));
   }
 
   /**

--- a/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
@@ -35,7 +35,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Stream;
 import org.hisp.dhis.jsontree.JsonNode.Index;
 import org.hisp.dhis.jsontree.Validation.Rule;
 import org.hisp.dhis.jsontree.internal.TerminalOp;

--- a/src/main/java/org/hisp/dhis/jsontree/JsonPrimitive.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonPrimitive.java
@@ -38,7 +38,7 @@ import static org.hisp.dhis.jsontree.Validation.NodeType.STRING;
  */
 @Validation(type = {BOOLEAN, NUMBER, STRING})
 @Validation.Ignore
-public interface JsonPrimitive extends JsonBoolean, JsonNumber, JsonString {
+public interface JsonPrimitive extends JsonBoolean, JsonString, JsonInteger {
 
   @Override
   default JsonPrimitive getValue() {

--- a/src/main/java/org/hisp/dhis/jsontree/JsonTree.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonTree.java
@@ -322,12 +322,12 @@ record JsonTree(
     }
 
     @Override
-    public Streamable<JsonNode> members() {
+    public Streamable.Sized<JsonNode> members() {
       return members(Index.AUTO);
     }
 
     @Override
-    public Streamable<JsonNode> members(Index op) {
+    public Streamable.Sized<JsonNode> members(Index op) {
       if (isEmpty()) return Streamable.empty();
       return new Streamable.Sized<>() {
         private final char[] json = tree.json;
@@ -383,12 +383,12 @@ record JsonTree(
     }
 
     @Override
-    public Streamable<JsonPath> paths() {
+    public Streamable.Sized<JsonPath> paths() {
       return keysSized(path::chain);
     }
 
     @Override
-    public Streamable<Text> keys() {
+    public Streamable.Sized<Text> keys() {
       return keysSized(name -> name);
     }
 
@@ -562,12 +562,12 @@ record JsonTree(
     }
 
     @Override
-    public Streamable<JsonNode> elements() {
+    public Streamable.Sized<JsonNode> elements() {
       return elements(Index.AUTO);
     }
 
     @Override
-    public Streamable<JsonNode> elements(Index op) {
+    public Streamable.Sized<JsonNode> elements(Index op) {
       if (isEmpty()) return Streamable.empty();
       return new Streamable.Sized<>() {
         private final char[] json = tree.json;
@@ -600,7 +600,7 @@ record JsonTree(
     }
 
     @Override
-    public Streamable<Text> values() {
+    public Streamable.Sized<Text> values() {
       if (isEmpty()) return Streamable.empty();
       return new Streamable.Sized<>() {
         private final char[] json = tree.json;

--- a/src/main/java/org/hisp/dhis/jsontree/JsonValue.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonValue.java
@@ -394,7 +394,7 @@ public interface JsonValue extends JsonProbe, JsonSelectable<JsonMixed>, Map.Ent
     if (a.isNumber()) return a.doubleValue() == b.doubleValue();
     if (a.isArray())
       return a.size() == b.size() && a.indexes().allMatch(i -> eqItems.test(a.get(i), b.get(i)));
-    return a.size() == b.size() && a.keys().allMatch(key -> eqItems.test(a.get(key), b.get(key)));
+    return a.size() == b.size() && a.keys().stream().allMatch(key -> eqItems.test(a.get(key), b.get(key)));
   }
 
   /**

--- a/src/main/java/org/hisp/dhis/jsontree/JsonVirtualTree.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonVirtualTree.java
@@ -79,6 +79,7 @@ final class JsonVirtualTree implements JsonMixed, Serializable {
       new JsonVirtualTree(JsonNode.NULL, JsonPath.SELF, JsonAccess.GLOBAL);
 
   private static final Map<Class<?>, List<Property>> PROPERTIES = new ConcurrentHashMap<>();
+  private static final Map<Class<?>, List<Property>> COLLAPSED_PROPERTIES = new ConcurrentHashMap<>();
 
   static List<Property> properties(Class<?> of) {
     if (JsonObject.class.isAssignableFrom(of)) {
@@ -93,6 +94,10 @@ final class JsonVirtualTree implements JsonMixed, Serializable {
     }
     throw new UnsupportedOperationException(
         "Must be a subtype of JsonObject or Record but was: " + of);
+  }
+
+  static List<Property> collapsedProperties(Class<? extends Record> of) {
+    return COLLAPSED_PROPERTIES.computeIfAbsent(of, type -> collapsedComponentProperties(of));
   }
 
   static JsonMixed lift(JsonNode node, JsonAccessors accessors) {
@@ -473,6 +478,26 @@ final class JsonVirtualTree implements JsonMixed, Serializable {
     } else {
       str.append('?');
     }
+  }
+
+  private static List<Property> collapsedComponentProperties(Class<? extends Record> of) {
+    List<Property> res = new ArrayList<>();
+    List<Property> properties = componentProperties(of);
+    for (Property p : properties) {
+      if (p.source().isAnnotationPresent(Collapsed.class)) {
+        Type type = p.javaType().getType();
+        if (type instanceof Class<?> c && c.isRecord()) {
+          @SuppressWarnings("unchecked")
+          Class<? extends Record> rType = (Class<? extends Record>) type;
+          res.addAll(collapsedComponentProperties(rType));
+        } else {
+          res.add(p);
+        }
+      } else {
+        res.add(p);
+      }
+    }
+    return List.copyOf(res);
   }
 
   private static List<Property> componentProperties(Class<? extends Record> of) {

--- a/src/main/java/org/hisp/dhis/jsontree/Streamable.java
+++ b/src/main/java/org/hisp/dhis/jsontree/Streamable.java
@@ -2,10 +2,13 @@ package org.hisp.dhis.jsontree;
 
 import static java.util.Collections.emptyIterator;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Spliterator;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.hisp.dhis.jsontree.internal.NotNull;
@@ -90,6 +93,34 @@ public interface Streamable<T> extends Iterable<T> {
     @Override
     default int characteristics() {
       return ORDERED | SIZED | NONNULL | IMMUTABLE;
+    }
+
+    default <E> Sized<E> map(Function<T, E> f) {
+      Sized<T> self = this;
+      return new Sized<E>() {
+        @Override
+        public long getExactSizeIfKnown() {
+          return self.getExactSizeIfKnown();
+        }
+
+        @Override
+        public boolean hasNext() {
+          return self.hasNext();
+        }
+
+        @Override
+        public E next() {
+          return f.apply(self.next());
+        }
+      };
+    }
+
+    default List<T> toList() {
+      int size = (int) getExactSizeIfKnown();
+      if (size == 0) return List.of();
+      List<T> res = new ArrayList<>(size);
+      while (hasNext()) res.add(next());
+      return res;
     }
   }
 

--- a/src/main/java/org/hisp/dhis/jsontree/Streamable.java
+++ b/src/main/java/org/hisp/dhis/jsontree/Streamable.java
@@ -115,12 +115,22 @@ public interface Streamable<T> extends Iterable<T> {
       };
     }
 
+    /**
+     * @see Stream#toList()
+     */
     default List<T> toList() {
       int size = (int) getExactSizeIfKnown();
       if (size == 0) return List.of();
       List<T> res = new ArrayList<>(size);
       while (hasNext()) res.add(next());
       return res;
+    }
+
+    /**
+     * @see Stream#count()
+     */
+    default long count() {
+      return getExactSizeIfKnown();
     }
   }
 

--- a/src/main/java/org/hisp/dhis/jsontree/TextualNumber.java
+++ b/src/main/java/org/hisp/dhis/jsontree/TextualNumber.java
@@ -31,6 +31,13 @@ public final class TextualNumber extends Number implements Textual {
   /**
    * Does not allow whitespace at start/end of the number.
    *
+   * <p>The returned number type is chosen to reflect the input text as close as possible. An
+   * integer input will result in {@link Integer} or {@link Long} based on numeric range as long as
+   * the range allows for it based on digit count (not exact numeric range). An input with decimals
+   * will result in {@link Double} for zero or a {@link TextualNumber} for anything else. Negative
+   * zero will always return a {@link Double} to preserve the distinction between positive and
+   * negative zero.
+   *
    * @param buffer with content of an integer or decimal number
    * @param offset start of the number in the buffer
    * @param length number of characters from offset that represent the number
@@ -59,6 +66,8 @@ public final class TextualNumber extends Number implements Textual {
         return new TextualNumber(buffer, offset, length);
       }
     }
+    if (isNumericZero(buffer, offset, length))
+      return buffer[offset] == '-' ? -0d : 0d;
     if (!isTextualDecimal(buffer, offset, length) && !Text.of(buffer, offset, length).isSpecialDecimal())
       throw nanError(buffer, offset, length, "Is neither an integer nor a decimal number: ");
     return new TextualNumber(buffer, offset, length);
@@ -169,10 +178,12 @@ public final class TextualNumber extends Number implements Textual {
     int end = offset + length;
     int d0 = i;
     while (i < end && buffer[i] == '0') i++;
-    if (i >= end) return i > d0;
+    boolean integerDigits = i > d0;
+    if (i >= end) return integerDigits;
     if (buffer[i++] != '.') return false;
+    d0 = i;
     while (i < end && buffer[i] == '0') i++;
-    return i == end;
+    return i == end && (integerDigits || i > d0);
   }
 
   static boolean isNumericInteger(char[] buffer) {

--- a/src/main/java/org/hisp/dhis/jsontree/Validation.java
+++ b/src/main/java/org/hisp/dhis/jsontree/Validation.java
@@ -177,6 +177,7 @@ public @interface Validation {
     static Class<? extends JsonValue> toJsonType(Class<?> type) {
       if (type == String.class || type.isEnum()) return JsonString.class;
       if (type == Character.class || type == char.class) return JsonString.class;
+      if (type == Class.class) return JsonString.class;
       if (type == Date.class) return JsonDate.class;
       if (type == LocalDate.class || type == LocalTime.class || type == LocalDateTime.class) return JsonMixed.class;
       if (type == Boolean.class || type == boolean.class) return JsonBoolean.class;

--- a/src/main/java/org/hisp/dhis/jsontree/validation/ObjectValidation.java
+++ b/src/main/java/org/hisp/dhis/jsontree/validation/ObjectValidation.java
@@ -222,12 +222,12 @@ record ObjectValidation(
 
   @NotNull
   private static PropertyValidations toPropertyValidation(Class<?> type) {
-    RequiredValidation values =
+    RequiredValidation requiredness =
         !type.isPrimitive() ? null : RequiredValidation.PRIMITIVES;
     StringValidation strings =
         !type.isEnum() ? null : new StringValidation(anyOfStrings(type), YesNo.AUTO, -1, -1, null);
     return new PropertyValidations(
-        NodeType.of(type), PropertyValidations.Strict.DEFAULT, List.of(), values, strings, null, null, null, null);
+        NodeType.of(type), PropertyValidations.Strict.DEFAULT, List.of(), requiredness, strings, null, null, null, null);
   }
 
   @NotNull

--- a/src/main/java/org/hisp/dhis/jsontree/validation/ObjectValidator.java
+++ b/src/main/java/org/hisp/dhis/jsontree/validation/ObjectValidator.java
@@ -196,7 +196,8 @@ record ObjectValidator(@NotNull Class<?> schema, @NotNull Map<JsonPath, Validato
    * possible and if required is AUTO
    */
   private static boolean isRequiredImplicitly(PropertyValidations validations) {
-    return validations.accepted().stream().allMatch(type -> isRequiredImplicitly(validations, type));
+    Set<NodeType> accepted = validations.accepted();
+    return !accepted.isEmpty() && accepted.stream().allMatch(type -> isRequiredImplicitly(validations, type));
   }
 
   private static boolean isRequiredImplicitly(PropertyValidations validations, NodeType type) {

--- a/src/test/java/org/hisp/dhis/jsontree/JsonApiPerfTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonApiPerfTest.java
@@ -141,12 +141,12 @@ class JsonApiPerfTest {
   @Test
   void testJsonArray_stream() {
     JsonArray arr = JsonMixed.of("[ 1,2 , true , false, \"hello\",{},[]]");
-    List<JsonNode> nodes = arr.stream(Index.SKIP).map(JsonValue::node).toList();
-    List<JsonNode> nodes2 = arr.stream(Index.SKIP).map(JsonValue::node).toList();
+    List<JsonNode> nodes = arr.values(Index.SKIP).map(JsonValue::node).toList();
+    List<JsonNode> nodes2 = arr.values(Index.SKIP).map(JsonValue::node).toList();
     for (int i = 0; i < nodes.size(); i++)
       assertNotSame(nodes.get(i), nodes2.get(i));
-    nodes = arr.stream(Index.ADD).map(JsonValue::node).toList();
-    nodes2 = arr.stream(Index.CHECK).map(JsonValue::node).toList();
+    nodes = arr.values(Index.ADD).map(JsonValue::node).toList();
+    nodes2 = arr.values(Index.CHECK).map(JsonValue::node).toList();
     for (int i = 0; i < nodes.size(); i++)
       assertSame(nodes.get(i), nodes2.get(i));
   }

--- a/src/test/java/org/hisp/dhis/jsontree/JsonApiPerfTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonApiPerfTest.java
@@ -101,12 +101,12 @@ class JsonApiPerfTest {
   }
 
   @Test
-  void testJsonValue_streamValues() {
+  void testJsonValue_values() {
     List<JsonPath> accessed = new ArrayList<>();
     JsonObject root = JsonMixed.of(JsonNode.of("{\"values\":[1,2,3,4,5]", accessed::add));
 
     assertEquals(List.of(), accessed);
-    assertEquals(5L, root.getArray("values").streamValues(double.class).count());
+    assertEquals(5L, root.getArray("values").values(double.class).count());
     assertEquals(List.of(JsonPath.of("values")), accessed, "there should be one access of values");
   }
 

--- a/src/test/java/org/hisp/dhis/jsontree/JsonArrayTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonArrayTest.java
@@ -76,16 +76,6 @@ class JsonArrayTest {
   }
 
   @Test
-  void testValues_Mapped() {
-    // language=json
-    String json =
-        """
-            ["a","b","c"]""";
-    JsonMixed arr = JsonMixed.of(json);
-    assertEquals(List.of('a', 'b', 'c'), arr.values(str -> str.charAt(0)));
-  }
-
-  @Test
   void testGetList_IndexAs() {
     JsonMixed arr = JsonMixed.of("[[1,2], [3,4]]");
     assertEquals(List.of(1, 2), arr.getList(0, JsonNumber.class).toList(JsonNumber::integer));
@@ -111,13 +101,9 @@ class JsonArrayTest {
   }
 
   @Test
-  void testListValues() {
-    assertEquals(List.of(1d, NaN, 3.1d), Json5.of("[1, NaN, 3.1]").listValues(double.class));
-  }
-
-  @Test
-  void streamValues() {
+  void testValues_ToClass() {
+    assertEquals(List.of(1d, NaN, 3.1d), Json5.of("[1, NaN, 3.1]").values(double.class).toList());
     assertEquals(
-        Stream.of(1, 2, 3).toList(), Json5.of("[1, '2', 3.0]").streamValues(int.class).toList());
+        List.of(1, 2, 3), Json5.of("[1, '2', 3.0]").values(int.class).toList());
   }
 }

--- a/src/test/java/org/hisp/dhis/jsontree/JsonMapTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonMapTest.java
@@ -135,10 +135,10 @@ class JsonMapTest {
   }
 
   @Test
-  void testViewAsMap_Values() {
+  void testViewAsMap_entries() {
     JsonMap<JsonArray> obj = JsonMixed.of("{\"b\":[1],\"c\":[2]}").asMap(JsonArray.class);
     JsonMap<JsonNumber> view = obj.project(arr -> arr.getNumber(0));
-    assertEquals(List.of(1, 2), view.values().map(JsonNumber::intValue).toList());
+    assertEquals(List.of(1, 2), view.entries().map(JsonNumber::intValue).toList());
   }
 
   @Test
@@ -151,16 +151,16 @@ class JsonMapTest {
   }
 
   @Test
-  void testValues_Special() {
+  void testEntries_Special1() {
     String json =
         """
             {".":1, "{uid}":2, "[6]":3, "x{y}z": 4}""";
     JsonMap<JsonNumber> map = JsonMixed.of(json).asMap(JsonNumber.class);
-    assertEquals(List.of(1, 2, 3, 4), map.values().map(JsonNumber::intValue).toList());
+    assertEquals(List.of(1, 2, 3, 4), map.entries().map(JsonNumber::intValue).toList());
   }
 
   @Test
-  void testEntries_Special() {
+  void testEntries_Special2() {
     String json =
         """
             {".":1, "{uid}":2, "[6]":3, "x{y}z": 4}""";

--- a/src/test/java/org/hisp/dhis/jsontree/JsonNumberTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonNumberTest.java
@@ -1,6 +1,7 @@
 package org.hisp.dhis.jsontree;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
@@ -167,6 +168,16 @@ class JsonNumberTest {
   }
 
   @Test
+  void testNumber() {
+    assertEquals(3, JsonMixed.of("3").number());
+    assertEquals(-0d, JsonMixed.of("-0").number());
+    assertTextualNumberEquals(3.0d, JsonMixed.of("3.0").number());
+    assertTextualNumberEquals(3.14d, JsonMixed.of("3.14").number());
+    assertEquals(0d, JsonMixed.of("0.0").number());
+    assertEquals(-0d, JsonMixed.of("-0.0").number());
+  }
+
+  @Test
   void testIrregularNumberPersistence() {
     JsonMixed big =
         JsonMixed.of(
@@ -185,5 +196,10 @@ class JsonNumberTest {
           "big-two": 99999999999999999999999999999999999999999999999999999999999999999999999999999999999999
         }""",
         root.getDeclaration().toString());
+  }
+
+  private static void assertTextualNumberEquals(double expected, Number actual) {
+    assertEquals(expected, actual.doubleValue());
+    assertInstanceOf(TextualNumber.class, actual);
   }
 }

--- a/src/test/java/org/hisp/dhis/jsontree/JsonValueToTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonValueToTest.java
@@ -19,14 +19,22 @@ import org.junit.jupiter.api.Test;
  */
 class JsonValueToTest {
 
-  public record ExampleParams(
+  public record OuterParams(
       int number,
       Integer optionalNumber,
       String string,
       Set<JsonNodeType> types,
       List<ExampleItem> items,
-      ExampleItem fallback
+      ExampleItem fallback,
+      @Collapsed InnerParams inner
   ) {}
+
+  public record InnerParams(
+      String foo,
+      @Collapsed InnerInnerParams inner
+  ) {}
+
+  public record InnerInnerParams(String bar) {}
 
   @Validation(type = NodeType.STRING)
   public record ExampleItem(String key, double value) {
@@ -39,14 +47,17 @@ class JsonValueToTest {
 
   @Test
   void testMinimal() {
+    InnerParams inner = new InnerParams(null, new InnerInnerParams(null));
     assertParamsEquals(
-        new ExampleParams(10, null, null, null, null, null), Map.of("number", List.of("10")));
+        new OuterParams(10, null, null, null, null, null, inner),
+        Map.of("number", List.of("10")));
   }
 
   @Test
   void testEmpty() {
+    InnerParams inner = new InnerParams(null, new InnerInnerParams(null));
     assertParamsEquals(
-        new ExampleParams(10, null, null, Set.of(), List.of(), null),
+        new OuterParams(10, null, null, Set.of(), List.of(), null, inner),
         Map.ofEntries(
             entry("number", List.of("10")),
             entry("optionalNumber", List.of()),
@@ -59,43 +70,48 @@ class JsonValueToTest {
   @Test
   void testMaximal() {
     assertParamsEquals(
-        new ExampleParams(
+        new OuterParams(
             10,
             20,
             "hello",
             Set.of(JsonNodeType.STRING, JsonNodeType.NULL),
             List.of(new ExampleItem("a", 1.5), new ExampleItem("b", 2.0)),
-            new ExampleItem("c", 5)),
+            new ExampleItem("c", 5),
+            new InnerParams("foo", new InnerInnerParams("bar"))),
         Map.ofEntries(
             entry("number", List.of("10")),
             entry("optionalNumber", List.of("20")),
             entry("string", List.of("hello")),
             entry("types", List.of("STRING", "NULL")),
             entry("items", List.of("a:1.5", "b:2.0")),
-            entry("fallback", List.of("c:5"))));
+            entry("fallback", List.of("c:5")),
+            entry("foo", List.of("foo")),
+            entry("bar", List.of("bar"))));
   }
 
   @Test
   void testSingle() {
     assertParamsEquals(
-        new ExampleParams(
+        new OuterParams(
             10,
             20,
             "hello",
             Set.of(JsonNodeType.STRING),
             List.of(new ExampleItem("a", 1.5)),
-            new ExampleItem("c", 5)),
+            new ExampleItem("c", 5),
+            new InnerParams("foo2", new InnerInnerParams(null))),
         Map.ofEntries(
             entry("number", List.of("10")),
             entry("optionalNumber", List.of("20")),
             entry("string", List.of("hello")),
             entry("types", List.of("STRING")),
             entry("items", List.of("a:1.5")),
-            entry("fallback", List.of("c:5"))));
+            entry("fallback", List.of("c:5")),
+            entry("foo", List.of("foo2"))));
   }
 
-  private static void assertParamsEquals(ExampleParams expected, Map<String, List<String>> actual) {
-    List<JsonObject.Property> properties = JsonObject.properties(ExampleParams.class);
+  private static void assertParamsEquals(OuterParams expected, Map<String, List<String>> actual) {
+    List<JsonObject.Property> properties = JsonObject.collapsedProperties(OuterParams.class);
     JsonNode object =
         JsonBuilder.createObject(
             obj -> {
@@ -132,7 +148,7 @@ class JsonValueToTest {
               }
             });
     JsonMixed params = JsonMixed.of(object);
-    params.validate(ExampleParams.class);
-    assertEquals(expected, params.to(ExampleParams.class));
+    params.validate(OuterParams.class);
+    assertEquals(expected, params.to(OuterParams.class));
   }
 }

--- a/src/test/java/org/hisp/dhis/jsontree/TextualNumberTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/TextualNumberTest.java
@@ -241,6 +241,9 @@ class TextualNumberTest {
     assertNumericZero("00.00");
     assertNumericZero("-00.00");
 
+    assertNotNumericZero(".");
+    assertNotNumericZero("+.");
+    assertNotNumericZero("-.");
     assertNotNumericZero("1");
     assertNotNumericZero("0.1");
     assertNotNumericZero("0.0001");

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMiscTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMiscTest.java
@@ -1,9 +1,13 @@
 package org.hisp.dhis.jsontree.validation;
 
 import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
+import static org.hisp.dhis.jsontree.Validation.Mode.PROBE_ALL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.annotation.RetentionPolicy;
+import java.util.List;
+
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonObject;
@@ -59,5 +63,22 @@ class JsonValidationMiscTest {
         Validation.Rule.MAX_LENGTH,
         5,
         10);
+  }
+
+  public record ImplicitlyRequired(int intValue, long longValue, double doubleValue, float floatValue) {}
+
+  @Test
+  void testPrimitivesAreImplicitlyRequired() {
+    Validation.Result result = JsonMixed.of("{}").validate(ImplicitlyRequired.class, PROBE_ALL);
+    assertEquals(4, result.errors().size());
+    assertTrue(result.errors().stream().allMatch(e -> e.rule() == Validation.Rule.REQUIRED));
+  }
+
+  public record NotImplicitlyRequired(Class<?> type) {}
+
+  @Test
+  void testNotImplicitlyRequired() {
+    Validation.Result result = JsonMixed.of("{}").validate(NotImplicitlyRequired.class, PROBE_ALL);
+    assertEquals(List.of(), result.errors());
   }
 }

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMiscTypeUseTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationMiscTypeUseTest.java
@@ -19,7 +19,7 @@ class JsonValidationMiscTypeUseTest {
                 @Validator(value = Validation.RegEx.class, params = @Validation(pattern = ".es.*"))
                 String>>
         getData() {
-      return getArray("data").values(e -> List.of());
+      return getArray("data").values().map(e -> List.of(e.text().toString())).toList();
     }
   }
 


### PR DESCRIPTION
### API Changes
These changes were made to provide a more versatile API while at the same time have less specialized methods and avoid unnecessary re-wrapping or API elevation on the caller side as in case of `Iterator` => `Stream`.

Backwards incompatible changes:

- :ab: object `keys()` now returns `Streamable.Sized`
- :ab: object `entries()` now returns `Streamable.Sized`
- :x: object `values()` is obsolete as `entries()` is identical (`values()` for objects needed to be removed as it otherwise would have clashed with newly added method of same name for arrays as `JsonMixed` extends both)
- :x: removed 1.9 array additions of `listValues`, `streamValues` and `values(Function)` which all can done via `values`

Backwards compatible changes (apart from potential name clashes in extending types):

- :new: array `values()` allows array element access as `Streamable.Sized<JsonMixed>` (enables use in for-each while also provide stream access)
- :new: array `values(Index)` (same as above but with control over index behaviour)
- :new: array `values(Class)` (same as above but with included access as a "mapped" type, e.g. a `record`)
- :sparkles: `JsonMixed` now extends `JsonPrimitive` as well
- :ab: `JsonNode#members` now returns `Streamable.Sized` (not `Streamable`)
- :ab: `JsonNode#paths` now returns `Streamable.Sized` (not `Streamable`)
- :ab: `JsonNode#elements` now returns `Streamable.Sized` (not `Streamable`)
- :ab: `JsonNode#values` now returns `Streamable.Sized` (not `Streamable`)

### Compose `to`-targets using `@Collapsed` inner records
- :new: when accessing objects as `record` types the records now can have components that are annotated with new annotation `@Collapsed` to map a "flat" JSON object to a structured Java composition of components from different types. This is quite essential for `record` types as inheritance as a means of composition is not possible. With this feature records can now achieve the equivalent of multiple-inheritance by composing multiple inner `@Collapsed` `record`s within a root or parent `record` type.
- :new: `JsonObject#collapsedProperties` to get a types properties with `@Collapsed` inner properties flattened into the list

Note that inner records are never `null` when accessed via `to` even if all of their properties are not present in the input JSON. This is so there is a simple, clear contract that avoids NPEs and is easy to implement. 


### Other Improvements
- :sparkles: Java `Number` of a JSON number value with numeric zero value having `0` decimal digit(s) does not result in `TextualNumber` but a `Double`
- :new:  `Streamable.Sized` now has `map` and `toList` (like a `Stream`) which often avoid the need to even elevate to a `Stream` so that iteration occurs directly on a mapped `Iterator`
- :new: `Class` properties are now automatically considered string properties

### Bugfixes
- :bug: fixed that properties that accept all nodes types are accepted implicitly must not be considered required because of it
- :bug: fixed that some non-zero non-numeric inputs such as `.` where wrongly considered zero by `TextualNumber#isNumericZero`

### Automatic Testing
- new cases where added to test the bugs found in `TextualNumber`
- existing test scenarios were extended to contain examples of `@Collapsed` inner `record`s