### PR TITLE
fix: always include collapsed properties in properties list

### DIFF
--- a/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonObject.java
@@ -88,21 +88,12 @@ public interface JsonObject extends JsonAbstractObject<JsonMixed> {
    * access is a property of the accessed {@link Property#jsonName()} with the same {@link
    * Property#javaName()}.
    *
-   * @return a model of this object in form its properties in no particular order
+   * @return a model of this object in form its properties in no particular order, including {@link
+   *     Collapsed} properties for {@link Record}s
    * @since 1.4
    */
   static List<Property> properties(Class<?> of) {
     return JsonVirtualTree.properties(of);
-  }
-
-  /**
-   * @param of an object type
-   * @return a list of the properties in the given object type including those collapsed down from
-   *     {@link Collapsed} inner {@link Record}s
-   * @since 1.9
-   */
-  static List<Property> collapsedProperties(Class<? extends Record> of) {
-    return JsonVirtualTree.collapsedProperties(of);
   }
 
   /**

--- a/src/main/java/org/hisp/dhis/jsontree/JsonVirtualTree.java
+++ b/src/main/java/org/hisp/dhis/jsontree/JsonVirtualTree.java
@@ -79,7 +79,6 @@ final class JsonVirtualTree implements JsonMixed, Serializable {
       new JsonVirtualTree(JsonNode.NULL, JsonPath.SELF, JsonAccess.GLOBAL);
 
   private static final Map<Class<?>, List<Property>> PROPERTIES = new ConcurrentHashMap<>();
-  private static final Map<Class<?>, List<Property>> COLLAPSED_PROPERTIES = new ConcurrentHashMap<>();
 
   static List<Property> properties(Class<?> of) {
     if (JsonObject.class.isAssignableFrom(of)) {
@@ -90,14 +89,10 @@ final class JsonVirtualTree implements JsonMixed, Serializable {
     if (Record.class.isAssignableFrom(of)) {
       @SuppressWarnings("unchecked")
       Class<? extends Record> type = (Class<? extends Record>) of;
-      return PROPERTIES.computeIfAbsent(type, t -> componentProperties(type));
+      return PROPERTIES.computeIfAbsent(type, t -> collapsedComponentProperties(type));
     }
     throw new UnsupportedOperationException(
         "Must be a subtype of JsonObject or Record but was: " + of);
-  }
-
-  static List<Property> collapsedProperties(Class<? extends Record> of) {
-    return COLLAPSED_PROPERTIES.computeIfAbsent(of, type -> collapsedComponentProperties(of));
   }
 
   static JsonMixed lift(JsonNode node, JsonAccessors accessors) {

--- a/src/test/java/org/hisp/dhis/jsontree/JsonValueToTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/JsonValueToTest.java
@@ -111,7 +111,7 @@ class JsonValueToTest {
   }
 
   private static void assertParamsEquals(OuterParams expected, Map<String, List<String>> actual) {
-    List<JsonObject.Property> properties = JsonObject.collapsedProperties(OuterParams.class);
+    List<JsonObject.Property> properties = JsonObject.properties(OuterParams.class);
     JsonNode object =
         JsonBuilder.createObject(
             obj -> {

--- a/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationRecordTest.java
+++ b/src/test/java/org/hisp/dhis/jsontree/validation/JsonValidationRecordTest.java
@@ -4,6 +4,8 @@ import static org.hisp.dhis.jsontree.Assertions.assertValidationError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.function.Consumer;
+
+import org.hisp.dhis.jsontree.Collapsed;
 import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.Validation;
 import org.hisp.dhis.jsontree.Validator;
@@ -18,7 +20,11 @@ import org.junit.jupiter.api.Test;
 class JsonValidationRecordTest {
 
   record SomeBean(
-      @Validation(minimum = 0) int age, @Validator(CustomValidator.class) String pattern) {}
+      @Validation(minimum = 0) int age,
+      @Validator(CustomValidator.class) String pattern,
+      @Collapsed InnerBean inner) {}
+
+  record InnerBean(@Validation(minLength = 10, required = Validation.YesNo.NO) String name) {}
 
   record CustomValidator() implements Validation.Validator {
 
@@ -32,7 +38,7 @@ class JsonValidationRecordTest {
   }
 
   @Test
-  void testMinimum_OK() {
+  void testRecord_Minimum_OK() {
     assertDoesNotThrow(
         () ->
             JsonMixed.of(
@@ -42,17 +48,27 @@ class JsonValidationRecordTest {
   }
 
   @Test
-  void testMinimum_Required() {
+  void testRecord_Minimum_Required() {
     assertValidationError("{}", SomeBean.class, Validation.Rule.REQUIRED, "age");
   }
 
   @Test
-  void testCustom_Validator() {
+  void testRecord_Custom_Validator() {
     assertValidationError(
         """
             {"age": 10, "pattern": "bar"}""",
         SomeBean.class,
         Validation.Rule.CUSTOM,
         "bar");
+  }
+
+  @Test
+  void testRecord_CollapsedValidation() {
+    assertValidationError(
+        """
+            {"age": 10, "pattern": "foo", "name": "tooShort"}""",
+        SomeBean.class,
+        Validation.Rule.MIN_LENGTH,
+        10, 8);
   }
 }


### PR DESCRIPTION
###Summary 
When testing I noticed that `@Collapsed` properties were not included in the validation because of the difference between `collapsedProperties` and `properties`. I found that I simply should always include the collapsed properties in the list of properties returned by `properties(Class)` making `collapsedProperties` unnecessary and avoiding a source of confusion and errors in the API.

### Automatic Testing
Added a new test case that checks that collapsed properties are validated when calling `validate` against the outer `Record` type